### PR TITLE
Add agency resume command

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
@@ -15,6 +15,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/runtime/checkpoint-integrity.md` — The optional HMAC checksum embedded in a checkpoint, and how a host verifies it.
 - `docs/dev/runtime/checkpointing.md` — Snapshotting execution state so a program can restore back to it later.
 - `docs/dev/runtime/rewind.md` — Replaying execution from a checkpoint, optionally with different values for its local variables.
+- `docs/dev/runtime/resume-command.md` — The `agency resume` child carrier, shared restore setup, overrides, integrity check, and lifecycle.
 - `docs/dev/runtime/trace.md` — Execution traces: a checkpoint per step, written to a file the debugger can replay.
 - `docs/dev/runtime/threads.md` — How LLM conversation history accumulates and flows through thread and subthread blocks.
 - `docs/dev/runtime/globalstore.md` — Module-namespaced storage for top-level variables at runtime.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -246,6 +246,7 @@ Other process docs:
 - `docs/dev/runtime/interrupts.md` — How a program resumes in the middle of a block after an interrupt, using step counters.
 - `docs/dev/runtime/lock.md` — A per-run mutex for serializing access to shared resources such as the terminal prompt.
 - `docs/dev/runtime/rewind.md` — Replaying execution from a checkpoint, optionally with different values for its local variables.
+- `docs/dev/runtime/resume-command.md` — The `agency resume` child carrier, shared restore setup, overrides, integrity check, and lifecycle.
 - `docs/dev/runtime/runBatch.md` — The one primitive that owns concurrent-interrupt orchestration for forks, parallel blocks, tool calls, and subprocesses.
 - `docs/dev/runtime/saveDraft.md` — How a scope's best-so-far value survives a guard trip instead of being lost.
 - `docs/dev/runtime/simplemachine.md` — The graph execution engine that runs compiled Agency programs.

--- a/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
@@ -25,10 +25,11 @@ Checkpoint creation signs but does not refuse: editing checkpoints is a
 supported feature, and trace mode writes a checkpoint per step. External hosts
 still choose whether to call `verifyCheckpointChecksum`.
 
-The `agency resume` command is an enforcing host. When
-`AGENCY_CHECKPOINT_KEY` is non-empty, its generated child verifies the raw
-parsed checkpoint before restoring it and refuses missing or invalid
-signatures. An unset or empty key disables both signing and this check.
+The `agency resume` command verifies any checkpoint that carries a signature.
+It first validates the checkpoint shape, then checks the signature with the
+configured current and retired keys. It refuses a signature it cannot verify;
+`--force` bypasses that refusal. Unsigned checkpoints remain editable and can
+be resumed without a key.
 
 ## Signing
 
@@ -54,11 +55,10 @@ order hashes identically. The checksum covers the whole checkpoint, so new
 fields are covered automatically. There is no algorithm field; the algorithm
 is fixed in code, and the domain tag changes if it ever does.
 
-Verification recomputes the canonical form from a checkpoint that came
-through `Checkpoint.fromJSON`, i.e. through the zod schemas — so a `toJSON`
-field missing from its schema makes a valid checkpoint verify false. Every
-new field on a checkpoint-tree `toJSON` must land in its schema in the same
-change.
+`Checkpoint.fromJSON` validates the checkpoint with the zod schemas before
+verification recomputes the canonical form. A `toJSON` field missing from its
+schema makes a valid checkpoint verify false. Every new field on a checkpoint
+tree must appear in the schema in the same change.
 
 ## The key
 

--- a/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
+++ b/packages/agency-lang/docs/dev/runtime/checkpoint-integrity.md
@@ -19,20 +19,24 @@ signature that validates under the configured key, compared in constant time.
 A missing signature returns false, so a caller cannot dodge verification by
 stripping the field.
 
-## Embed, do not enforce
+## Where verification is enforced
 
-The runtime signs but never refuses: editing checkpoints is a supported
-feature (rewind, the debugger, resume overrides), and trace mode writes a
-checkpoint per step. Enforcement is the host's policy — a host that has not
-opted in never calls verify.
+Checkpoint creation signs but does not refuse: editing checkpoints is a
+supported feature, and trace mode writes a checkpoint per step. External hosts
+still choose whether to call `verifyCheckpointChecksum`.
+
+The `agency resume` command is an enforcing host. When
+`AGENCY_CHECKPOINT_KEY` is non-empty, its generated child verifies the raw
+parsed checkpoint before restoring it and refuses missing or invalid
+signatures. An unset or empty key disables both signing and this check.
 
 ## Signing
 
 `Checkpoint.fromStateStack` is the single chokepoint every checkpoint is
 created through, and its last statement calls `signCheckpoint`. With no key in
 the environment that call is a no-op; with a key, every checkpoint comes out
-signed. The legitimate edit paths — `applyOverrides` (rewind and resume-time
-overrides), `CheckpointStore.pin`, `Checkpoint.clone` — re-sign, so an edited
+signed. The legitimate edit paths — resume-time overrides,
+`CheckpointStore.pin`, and `Checkpoint.clone` — re-sign, so an edited
 checkpoint stays self-consistent. Both functions also accept the plain parsed
 JSON form of a checkpoint, which is what the external resume path carries.
 

--- a/packages/agency-lang/docs/dev/runtime/resume-command.md
+++ b/packages/agency-lang/docs/dev/runtime/resume-command.md
@@ -1,0 +1,80 @@
+# Resume command
+
+`agency resume <checkpoint-file> <input.agency>` compiles the original program
+and resumes it at the checkpoint's saved source location. The command owns a
+complete CLI run. The debugger rewind and interrupt-response APIs remain
+separate.
+
+## Process boundary
+
+The parent CLI validates and resolves the checkpoint path, parses overrides,
+and compiles the input with the same options as `agency run`. It then starts the
+compiled child with two environment carriers:
+
+- `AGENCY_RESUME_FILE` is the absolute checkpoint path.
+- `AGENCY_RESUME_OVERRIDES` is JSON with `locals`, `args`, and `globals`
+  objects.
+
+`withRootCarriers` clears both variables for every child launch, including
+fresh runs. This prevents a nested or shell-inherited resume request from
+silently changing a later run.
+
+The generated executable calls `runCliEntry`. With no resume carrier it calls
+`main` as before. With a carrier it reads and validates the checkpoint, then
+calls the generated private `__resumeFromCheckpoint` binding. That binding
+supplies the compiled module's `__globalCtx` to the runtime. The public
+`rewindFrom(checkpoint, flatLocalOverrides, opts?)` export is unchanged.
+
+## Shared restore setup
+
+`restoreForResume` in `lib/runtime/resumeSetup.ts` is used by direct CLI resume,
+interrupt response, and debugger rewind. It checks code fingerprints before
+restoring state, reinstalls the root policy handler and host budget, reloads
+providers, registers top-level callbacks, and applies overrides. Handlers are
+not serialized, so installing the root policy on every resumed execution is a
+safety requirement.
+
+The direct CLI path uses the same resume loop as interrupt response. A resumed
+run can therefore interrupt again. Completion emits the agent lifecycle end,
+writes the trace footer, flushes statelog work, and releases the execution
+context. A new interrupt pauses the trace without a footer because the run has
+not finished.
+
+## Integrity and code identity
+
+When `AGENCY_CHECKPOINT_KEY` is non-empty, `runCliEntry` verifies the parsed
+checkpoint before reviving or editing it. A missing or invalid signature is
+fatal. An unset or empty key disables verification, matching checkpoint signing
+semantics. Code fingerprints are always checked after the generated program is
+loaded, so a checkpoint cannot resume against changed source code.
+
+## Overrides and program arguments
+
+The repeatable flags `--local-var`, `--arg`, and `--global-var` accept
+`name=value`. Agency parses each value as JSON when possible and otherwise uses
+the text unchanged. Local and argument overrides change the top checkpoint
+frame. Global overrides change the checkpoint's module namespace.
+
+Process arguments are not part of a checkpoint. Each `--program-arg <value>` is
+passed to the compiled child, where `std::args` can read it. With no such flags,
+a resumed program receives no program arguments.
+
+## Sandbox and run options
+
+`run` and `resume` share compilation and launch options, including model,
+local-model, policy, budget, trace, statelog, strictness, tool-loop limits,
+`--agency-only`, and `--capture-workdir`. In particular, resume must pass
+`--agency-only` through to both compile-time closure checking and the child
+runtime sandbox.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `lib/runtime/resumeSetup.ts` | Shared checkpoint restore preparation and overrides |
+| `lib/runtime/cliEntry.ts` | Generated child entry selection and checkpoint verification |
+| `lib/runtime/interrupts.ts` | Lifecycle-complete direct resume and shared resume loop |
+| `lib/cli/resumeOverrides.ts` | `name=value` parsing |
+| `lib/cli/resumeCarrier.ts` | Checkpoint path validation and carrier serialization |
+| `lib/cli/childEnv.ts` | Clears and installs child environment carriers |
+| `scripts/agency.ts` | `agency resume` command and shared run options |

--- a/packages/agency-lang/docs/dev/runtime/resume-command.md
+++ b/packages/agency-lang/docs/dev/runtime/resume-command.md
@@ -9,30 +9,32 @@ separate.
 
 The parent CLI validates and resolves the checkpoint path, parses overrides,
 and compiles the input with the same options as `agency run`. It then starts the
-compiled child with two environment carriers:
+compiled child with three environment carriers:
 
 - `AGENCY_RESUME_FILE` is the absolute checkpoint path.
 - `AGENCY_RESUME_OVERRIDES` is JSON with `locals`, `args`, and `globals`
   objects.
+- `AGENCY_RESUME_FORCE` is set when `--force` allows an unverifiable signed
+  checkpoint.
 
-`withRootCarriers` clears both variables for every child launch, including
+`withRootCarriers` clears all three variables for every child launch, including
 fresh runs. This prevents a nested or shell-inherited resume request from
 silently changing a later run.
 
 The generated executable calls `runCliEntry`. With no resume carrier it calls
 `main` as before. With a carrier it reads and validates the checkpoint, then
 calls the generated private `__resumeFromCheckpoint` binding. That binding
-supplies the compiled module's `__globalCtx` to the runtime. The public
-`rewindFrom(checkpoint, flatLocalOverrides, opts?)` export is unchanged.
+supplies the compiled module's `__globalCtx` to `resumeCliFromCheckpoint`. The
+public `rewindFrom(checkpoint, flatLocalOverrides, opts?)` export is unchanged.
 
 ## Shared restore setup
 
 `restoreForResume` in `lib/runtime/resumeSetup.ts` is used by direct CLI resume,
 interrupt response, and debugger rewind. It checks code fingerprints before
-restoring state, reinstalls the root policy handler and host budget, reloads
-providers, registers top-level callbacks, and applies overrides. Handlers are
-not serialized, so installing the root policy on every resumed execution is a
-safety requirement.
+restoring state. It reinstalls the root policy handler and host budget. It also
+reloads providers, registers top-level callbacks, and applies overrides.
+Handlers are not serialized, so every resumed execution installs the root
+policy again.
 
 The direct CLI path uses the same resume loop as interrupt response. A resumed
 run can therefore interrupt again. Completion emits the agent lifecycle end,
@@ -42,11 +44,12 @@ not finished.
 
 ## Integrity and code identity
 
-When `AGENCY_CHECKPOINT_KEY` is non-empty, `runCliEntry` verifies the parsed
-checkpoint before reviving or editing it. A missing or invalid signature is
-fatal. An unset or empty key disables verification, matching checkpoint signing
-semantics. Code fingerprints are always checked after the generated program is
-loaded, so a checkpoint cannot resume against changed source code.
+`runCliEntry` validates the checkpoint before checking its signature. A signed
+checkpoint must verify with a configured current or retired key unless the user
+passes `--force`. Unsigned checkpoints do not require a key. Code fingerprints
+are checked after the generated program is loaded, so a checkpoint cannot
+resume against changed source code. Agency-only compilation uses the original
+source paths as stable module identities and emits code fingerprints too.
 
 ## Overrides and program arguments
 
@@ -73,7 +76,7 @@ runtime sandbox.
 |------|------|
 | `lib/runtime/resumeSetup.ts` | Shared checkpoint restore preparation and overrides |
 | `lib/runtime/cliEntry.ts` | Generated child entry selection and checkpoint verification |
-| `lib/runtime/interrupts.ts` | Lifecycle-complete direct resume and shared resume loop |
+| `lib/runtime/interrupts.ts` | Lifecycle-complete CLI resume and shared resume loop |
 | `lib/cli/resumeOverrides.ts` | `name=value` parsing |
 | `lib/cli/resumeCarrier.ts` | Checkpoint path validation and carrier serialization |
 | `lib/cli/childEnv.ts` | Clears and installs child environment carriers |

--- a/packages/agency-lang/docs/dev/runtime/rewind.md
+++ b/packages/agency-lang/docs/dev/runtime/rewind.md
@@ -67,8 +67,9 @@ The implementation is `rewindFrom` in `lib/runtime/rewind.ts`. It:
 2. applies the overrides;
 3. mints a fresh run id and a fresh execution context, so a replay shows up as
    a distinct run in traces;
-4. registers top-level callbacks inside a bootstrap ALS frame, then calls
-   `restoreState(checkpoint)` and sets `_skipNextCheckpoint`;
+4. calls the shared `restoreForResume` setup, which verifies code identity,
+   reinstalls the root policy and budget, registers callbacks, and restores
+   state, then sets `_skipNextCheckpoint`;
 5. runs the checkpoint's node to completion, looping on `RestoreSignal` so a
    `restore()` inside the replay is honored;
 6. returns `createReturnObject({ result, globals })`, the same
@@ -108,6 +109,8 @@ so this replay is the only thing that puts them back.
 | File | Role |
 |------|------|
 | `lib/runtime/rewind.ts` | `rewindFrom`, `applyOverrides` |
+| `lib/runtime/resumeSetup.ts` | shared setup for rewind, interrupt response, and CLI resume |
+| `lib/runtime/interrupts.ts` | lifecycle-complete direct CLI resume |
 | `lib/runtime/checkpoint.ts` | `checkpoint()`, `getCheckpoint()`, `restore()` |
 | `lib/runtime/state/checkpointStore.ts` | `Checkpoint`, `CheckpointStore` |
 | `lib/runtime/debugger.ts` | `debugStep` — trace write plus rolling checkpoints |

--- a/packages/agency-lang/docs/dev/runtime/rewind.md
+++ b/packages/agency-lang/docs/dev/runtime/rewind.md
@@ -110,7 +110,7 @@ so this replay is the only thing that puts them back.
 |------|------|
 | `lib/runtime/rewind.ts` | `rewindFrom`, `applyOverrides` |
 | `lib/runtime/resumeSetup.ts` | shared setup for rewind, interrupt response, and CLI resume |
-| `lib/runtime/interrupts.ts` | lifecycle-complete direct CLI resume |
+| `lib/runtime/interrupts.ts` | lifecycle-complete CLI resume |
 | `lib/runtime/checkpoint.ts` | `checkpoint()`, `getCheckpoint()`, `restore()` |
 | `lib/runtime/state/checkpointStore.ts` | `Checkpoint`, `CheckpointStore` |
 | `lib/runtime/debugger.ts` | `debugStep` — trace write plus rolling checkpoints |

--- a/packages/agency-lang/docs/site/cli/run.md
+++ b/packages/agency-lang/docs/site/cli/run.md
@@ -1,6 +1,6 @@
 ---
 title: Running Agency code
-description: Documents the `agency run` command for compiling and executing an Agency file in one step, including the `--resume` and `--trace` options.
+description: Documents the `agency run` and `agency resume` commands for starting and continuing Agency programs.
 ---
 
 # Running Agency code
@@ -22,16 +22,42 @@ agency foo.agency
 The shorthand takes the same options and splits its command line the same way,
 so `agency greet.agency --name alice` works exactly like the `run` form below.
 
-Note: This compiles the file to JavaScript and immediately executes it under the same Node binary that's running the CLI. You can also pass `--resume <statefile>` to resume a previously saved execution, or `--trace` to write an execution trace.
+This compiles the file to JavaScript and immediately executes it under the same
+Node binary that is running the CLI. Use the separate `agency resume` command
+to continue from a saved checkpoint.
 
 ## Options
 
-- `--resume <statefile>` — resume execution from a saved state file. This is what you'd use to continue a run that paused at an interrupt, after writing the user's responses into the state file. *work in progress*
 - `--trace` — write an execution trace as the program runs, to `<input>.trace`. See [traces and bundles](./trace-and-bundle.html) for what you can do with a trace file.
 - `--trace-file <path>` — write the execution trace to this path instead.
 - `--max-cost <dollars>` — abort the run if its LLM spend exceeds this many dollars, e.g. `--max-cost 0.50`. `0` means no paid spend at all (local models only). A negative value means no limit. A tripped budget exits with code 3 and prints the overrun.
 - `--max-time <duration>` — abort the run if its working time exceeds this duration, e.g. `--max-time 5m`. The value needs a unit: `500ms`, `30s`, `5m`, `1h`, `2d`, `1w`. Time spent waiting on a human does not count. Zero or negative means no limit. A tripped budget exits with code 3.
 - `--model <name>` — the model this run's `llm()` calls use by default, written as `model` or `provider/model`. See [choosing a model](#choosing-a-model) below.
+
+## Resuming a checkpoint
+
+Use the checkpoint JSON and the same Agency source file:
+
+```bash
+agency resume checkpoint.json foo.agency
+```
+
+`resume` accepts the same model, policy, budget, trace, strictness,
+`--agency-only`, and capture options as `run`. It also accepts repeatable value
+overrides:
+
+```bash
+agency resume checkpoint.json foo.agency \
+  --local-var mood='"happy"' \
+  --arg input='{"retry":true}' \
+  --global-var attempts=8 \
+  --program-arg hello
+```
+
+Each `name=value` value is parsed as JSON when possible. Other values remain
+strings. `--program-arg` is separate because process arguments are not saved in
+a checkpoint. See [Checkpointing](../guide/checkpointing) for creating the JSON
+file and the integrity rules.
 
 ## Choosing a model
 

--- a/packages/agency-lang/docs/site/cli/run.md
+++ b/packages/agency-lang/docs/site/cli/run.md
@@ -56,8 +56,10 @@ agency resume checkpoint.json foo.agency \
 
 Each `name=value` value is parsed as JSON when possible. Other values remain
 strings. `--program-arg` is separate because process arguments are not saved in
-a checkpoint. See [Checkpointing](../guide/checkpointing) for creating the JSON
-file and the integrity rules.
+a checkpoint. Signed checkpoints are verified automatically; use `--force` to
+resume one whose signature cannot be verified. See
+[Checkpointing](../guide/checkpointing) for creating the JSON file and the
+integrity rules.
 
 ## Choosing a model
 

--- a/packages/agency-lang/docs/site/guide/checkpointing.md
+++ b/packages/agency-lang/docs/site/guide/checkpointing.md
@@ -56,8 +56,31 @@ You can take this one step further by getting the checkpoint and saving it to a 
 ```ts
 const id = checkpoint()
 const cp = getCheckpoint(id)
-saveToDisk(cp, "checkpoint.json")
+printJSON(cp)
 ```
+
+Copy the printed JSON object into `checkpoint.json`. Do not redirect the whole
+output of `agency run` into that file: the run banner and any other program
+output would make it invalid JSON.
+
+Resume it against the same source file:
+
+```bash
+agency resume checkpoint.json program.agency
+```
+
+You can change values in the current checkpoint frame while resuming:
+
+```bash
+agency resume checkpoint.json program.agency \
+  --local-var mood='"happy"' \
+  --arg input='{"retry":true}' \
+  --global-var attempts=8
+```
+
+Values are parsed as JSON when possible and otherwise treated as strings. Use
+repeated `--program-arg <value>` flags if the resumed program reads
+`std::args`; process arguments are not stored in checkpoints.
 
 This is kind of like saving your progress in a video game and coming back to it later.
 

--- a/packages/agency-lang/docs/site/guide/checkpointing.md
+++ b/packages/agency-lang/docs/site/guide/checkpointing.md
@@ -140,4 +140,7 @@ if (!verifyCheckpointChecksum(checkpoint)) {
 }
 ```
 
-This is strictly opt-in: you opt in to add the signature by setting the env var, and you need to manually check whether a checkpoint has been tampered with.
+Signing is opt-in. Hosts using the JavaScript API call
+`verifyCheckpointChecksum` themselves. `agency resume` checks a signature when
+one is present and refuses an invalid or unverifiable signature unless you pass
+`--force`.

--- a/packages/agency-lang/docs/superpowers/plans/2026-09-11-agency-resume-command.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-09-11-agency-resume-command.md
@@ -7,7 +7,7 @@ and interrupt machinery as `agency run`.
 
 **Compatibility:** Keep the existing public compiled-module API
 `rewindFrom(checkpoint, flatLocalOverrides, opts?)`. The CLI uses a new
-module-bound `resumeFromCheckpoint(checkpoint, ResumeOverrides)` entry so the
+module-bound `resumeCliFromCheckpoint(checkpoint, ResumeOverrides)` entry so the
 new override buckets do not silently change existing JavaScript callers.
 
 **Architecture:** Both interrupt responses and direct checkpoint-file resumes
@@ -16,7 +16,7 @@ installs the root policy handler, reloads providers, restores callbacks and
 state, reapplies the host budget, and applies override buckets. The callback
 `afterCheckpointRestored` lets `respondToInterruptsCore` preserve the current
 `checkpointRestored` then `interruptResolved` event ordering before later
-restore work can fail. `resumeFromCheckpoint` lives beside the existing
+restore work can fail. `resumeCliFromCheckpoint` lives beside the existing
 resume loop in `interrupts.ts`; it owns CLI lifecycle events and trace
 pause/close behavior. The generated entry calls `runCliEntry`, which selects
 fresh `main` or the module-bound resume function.
@@ -91,9 +91,12 @@ Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
    install response data after restore completes.
 5. Use `applyRestoreOverrides` in every `RestoreSignal` loop that supports
    restore options: `node.ts`, `interrupts.ts`, and `rewind.ts`.
-6. Keep the public `rewindFrom` flat-local signature. It calls
+6. Validate override keys in this shared layer, not only in the CLI parser.
+   Queue argument overrides when the checkpoint is paused inside a function so
+   the generated function preamble updates its live parameters.
+7. Keep the public `rewindFrom` flat-local signature. It calls
    `restoreForResume(..., { overrides: { locals: overrides } })`.
-7. Run the new unit test and the existing interrupt/checkpoint/rewind tests.
+8. Run the new unit test and the existing interrupt/checkpoint/rewind tests.
 
 ## Task 2: Lifecycle-complete direct resume
 
@@ -103,9 +106,9 @@ Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
 
 1. Write a failing test proving the existing flat form
    `rewindFrom(cp, { mood: "happy" })` still overrides `mood`.
-2. Add runtime `resumeFromCheckpoint({ ctx, checkpoint, overrides? })` beside
+2. Add runtime `resumeCliFromCheckpoint({ ctx, checkpoint, overrides? })` beside
    `runResumeLoop`. It creates a run id/context, restores with
-   `restoreForResume`, sets `_skipNextCheckpoint`, emits the same agent
+   `restoreForResume`, emits the same agent
    lifecycle/span events as an interrupt resume, runs with `endsRun: true`,
    pauses traces on interrupts, closes them with a footer on completion,
    flushes statelog requests, and cleans up on every path.
@@ -119,15 +122,18 @@ Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
 
 **Files:** Modify `lib/constants.ts`, `lib/runtime/index.ts`,
 `lib/templates/backends/typescriptGenerator/imports.mustache`, and
-`lib/backends/typescriptBuilder.ts`. Add `lib/runtime/cliEntry.ts` and its test.
+`lib/backends/typescriptBuilder.ts`, `lib/backends/typescriptGenerator.ts`, and
+the sandboxed compiler. Add `lib/runtime/cliEntry.ts` and its test.
 
-1. Add `AGENCY_RESUME_FILE` and `AGENCY_RESUME_OVERRIDES` constants.
-2. Write failing tests for fresh entry, unsigned resume without a key, valid
-   signed resume, tampered signed refusal, unsigned refusal with a configured
-   key, empty-key behavior, malformed checkpoint JSON, and overrides.
+1. Add `AGENCY_RESUME_FILE`, `AGENCY_RESUME_OVERRIDES`, and
+   `AGENCY_RESUME_FORCE` constants.
+2. Write failing tests for fresh entry, unsigned resume, valid signed resume,
+   tampered signed refusal, forced signed resume, malformed checkpoint JSON
+   with and without a signing key, and overrides.
 3. Implement `runCliEntry({ runMain, resume })`. Read and parse the checkpoint
-   only when `AGENCY_RESUME_FILE` exists. Verify its raw JSON when
-   `AGENCY_CHECKPOINT_KEY` is non-empty, matching `resolveKey()` semantics.
+   only when `AGENCY_RESUME_FILE` exists. Validate the checkpoint shape before
+   checking a present signature, and bypass a failed check only when the force
+   carrier is set.
 4. Change the generated main block to:
 
    ```ts
@@ -141,6 +147,9 @@ Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
 5. Run `pnpm run templates`, typecheck, `make fixtures`, the builder test, and
    the CLI-main integration test. Fixture diffs will include runtime imports,
    the private resume binding, and the generated entry.
+6. Emit fingerprint registration through the TypeScript IR before program
+   execution. Agency-only compilation uses each validated source file's
+   original path as its stable fingerprint identity.
 
 ## Task 4: Resume command and carriers
 
@@ -160,7 +169,8 @@ Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
    `--agency-only`, and `--capture-workdir` options. Remove the dead `--resume`
    flags from `run` and `trace run`.
 5. Add resume-only repeated `--local-var`, `--global-var`, `--arg`, and
-   `--program-arg` options. Pass `programArg` to `run()` as child argv.
+   `--program-arg` options, plus `-f, --force`. Pass `programArg` to `run()` as
+   child argv.
 6. Add spawn tests for local/default overrides, argument/global overrides,
    `--program-arg`, `--approve`, no-policy interrupt reporting,
    `--agency-only` compile refusal, trace footer creation, and malformed flags.

--- a/packages/agency-lang/docs/superpowers/plans/2026-09-11-agency-resume-command.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-09-11-agency-resume-command.md
@@ -1,0 +1,204 @@
+# `agency resume` Command Implementation Plan
+
+**Goal:** Add `agency resume <checkpoint-file> <input.agency>` with local,
+global, entry-argument, and program-argument overrides. A resumed CLI run must
+use the same compilation, sandbox, policy, budget, trace, capture, provider,
+and interrupt machinery as `agency run`.
+
+**Compatibility:** Keep the existing public compiled-module API
+`rewindFrom(checkpoint, flatLocalOverrides, opts?)`. The CLI uses a new
+module-bound `resumeFromCheckpoint(checkpoint, ResumeOverrides)` entry so the
+new override buckets do not silently change existing JavaScript callers.
+
+**Architecture:** Both interrupt responses and direct checkpoint-file resumes
+restore through `restoreForResume`. The helper verifies code fingerprints,
+installs the root policy handler, reloads providers, restores callbacks and
+state, reapplies the host budget, and applies override buckets. The callback
+`afterCheckpointRestored` lets `respondToInterruptsCore` preserve the current
+`checkpointRestored` then `interruptResolved` event ordering before later
+restore work can fail. `resumeFromCheckpoint` lives beside the existing
+resume loop in `interrupts.ts`; it owns CLI lifecycle events and trace
+pause/close behavior. The generated entry calls `runCliEntry`, which selects
+fresh `main` or the module-bound resume function.
+
+Program argv is process state, not checkpoint state. `agency resume` defaults
+it to empty and accepts repeated `--program-arg <value>` flags for programs
+that read `std::args`.
+
+## Constraints
+
+- Do not use dynamic imports.
+- Use objects instead of maps, arrays instead of sets, and types instead of interfaces.
+- Do not add symlink support.
+- Modify `.mustache` templates, then run `pnpm run templates`; never edit generated template `.ts` files.
+- Run `make fixtures` after changing the generated main entry.
+- Run `pnpm run fmt:ts` before each implementation commit.
+- Save test output to `/tmp`; do not run the full Agency execution suite.
+- Put spawned Agency fixtures under this package and remove them with
+  `safeDeleteDirectoryWithin`.
+- Keep every `if` body in braces and name nested option/function types.
+- Every resume context installs the root policy handler because handlers are
+  not serialized.
+
+## Task 1: Shared restore setup
+
+**Files:** Add `lib/runtime/resumeSetup.ts`,
+`lib/runtime/checkpointTestHelpers.ts`, and `lib/runtime/resumeSetup.test.ts`.
+Modify `lib/runtime/interrupts.ts`, `lib/runtime/node.ts`,
+`lib/runtime/rewind.ts`, and `lib/runtime/index.ts`.
+
+1. Add a test helper that constructs a checkpoint directly with
+   `new Checkpoint({ stack: stack.toJSON(), globals: globals.toJSON(), nodeId:
+   "main", moduleId: "", scopeName: "", stepPath: "" })`. Build the top frame
+   with `StateStack.getNewState()`.
+2. Write failing tests for local overrides, argument/global restore overrides,
+   no-op overrides, code-fingerprint refusal, root policy installation, root
+   budget replacement, callback metadata, and
+   `afterCheckpointRestored` ordering.
+3. Add:
+
+   ```ts
+   export type ResumeOverrides = {
+     locals?: Record<string, unknown>;
+     args?: Record<string, unknown>;
+     globals?: Record<string, unknown>;
+   };
+   export type ResumeMetadata = {
+     callbacks?: AgencyCallbacks;
+     debugger?: DebuggerState;
+   };
+   export type AfterCheckpointRestored = () => void;
+   export type ResumeRequest = {
+     checkpoint: Checkpoint;
+     policy?: Policy;
+     overrides?: ResumeOverrides;
+     metadata?: ResumeMetadata;
+     afterCheckpointRestored?: AfterCheckpointRestored;
+   };
+   export async function restoreForResume(
+     execCtx: RuntimeContext<GraphState>,
+     request: ResumeRequest,
+   ): Promise<void>;
+   ```
+
+   `restoreForResume` deep-clones the checkpoint, applies local overrides,
+   checks fingerprints, installs policy, reloads providers, records
+   `checkpointRestored`, calls `afterCheckpointRestored`, registers top-level
+   callbacks, restores state, reinstalls the root budget, applies args/globals,
+   and merges metadata.
+4. Replace the corresponding setup in `respondToInterruptsCore`. Emit the
+   existing `interruptResolved` loop through `afterCheckpointRestored`, then
+   install response data after restore completes.
+5. Use `applyRestoreOverrides` in every `RestoreSignal` loop that supports
+   restore options: `node.ts`, `interrupts.ts`, and `rewind.ts`.
+6. Keep the public `rewindFrom` flat-local signature. It calls
+   `restoreForResume(..., { overrides: { locals: overrides } })`.
+7. Run the new unit test and the existing interrupt/checkpoint/rewind tests.
+
+## Task 2: Lifecycle-complete direct resume
+
+**Files:** Modify `lib/runtime/interrupts.ts`, `lib/runtime/index.ts`,
+`lib/templates/backends/typescriptGenerator/imports.mustache`, and
+`docs/dev/runtime/rewind.md`. Add an Agency-JS compatibility test.
+
+1. Write a failing test proving the existing flat form
+   `rewindFrom(cp, { mood: "happy" })` still overrides `mood`.
+2. Add runtime `resumeFromCheckpoint({ ctx, checkpoint, overrides? })` beside
+   `runResumeLoop`. It creates a run id/context, restores with
+   `restoreForResume`, sets `_skipNextCheckpoint`, emits the same agent
+   lifecycle/span events as an interrupt resume, runs with `endsRun: true`,
+   pauses traces on interrupts, closes them with a footer on completion,
+   flushes statelog requests, and cleans up on every path.
+3. Keep `rewindFrom` debugger lifecycle unchanged (`endsRun: false`).
+4. Add a private generated binding named `__resumeFromCheckpoint`; do not
+   change the public `rewindFrom` wrapper signature.
+5. Add tests for args/globals through the new binding and for a resumed run
+   that raises another interrupt.
+
+## Task 3: Checkpoint-file generated entry
+
+**Files:** Modify `lib/constants.ts`, `lib/runtime/index.ts`,
+`lib/templates/backends/typescriptGenerator/imports.mustache`, and
+`lib/backends/typescriptBuilder.ts`. Add `lib/runtime/cliEntry.ts` and its test.
+
+1. Add `AGENCY_RESUME_FILE` and `AGENCY_RESUME_OVERRIDES` constants.
+2. Write failing tests for fresh entry, unsigned resume without a key, valid
+   signed resume, tampered signed refusal, unsigned refusal with a configured
+   key, empty-key behavior, malformed checkpoint JSON, and overrides.
+3. Implement `runCliEntry({ runMain, resume })`. Read and parse the checkpoint
+   only when `AGENCY_RESUME_FILE` exists. Verify its raw JSON when
+   `AGENCY_CHECKPOINT_KEY` is non-empty, matching `resolveKey()` semantics.
+4. Change the generated main block to:
+
+   ```ts
+   const __result = await runCliEntry({
+     runMain: () => main(undefined, ..., initialState),
+     resume: __resumeFromCheckpoint,
+   });
+   await resolveCliInterrupts(__result, respondToInterrupts);
+   ```
+
+5. Run `pnpm run templates`, typecheck, `make fixtures`, the builder test, and
+   the CLI-main integration test. Fixture diffs will include runtime imports,
+   the private resume binding, and the generated entry.
+
+## Task 4: Resume command and carriers
+
+**Files:** Modify `lib/cli/childEnv.ts`, `lib/cli/commands.ts`, and
+`scripts/agency.ts`. Add `lib/cli/resumeOverrides.ts`,
+`lib/cli/resumeCarrier.ts`, their tests, and `lib/cli/resume.spawn.test.ts`.
+
+1. Write failing tests for stale resume env clearing, carrier serialization,
+   JSON-or-string `key=value` parsing, embedded equals signs, malformed
+   assignments, missing checkpoint files, and null-prototype override objects.
+2. Add a `ResumeCarrier` to `withRootCarriers`. Clear both resume variables on
+   every child launch and set them only for a resume.
+3. Resolve checkpoint paths to absolute paths and parse the three override
+   buckets. Reject missing or non-file checkpoint paths.
+4. Refactor CLI option registration so both `run` and `resume` receive model,
+   local-model, trace/logging, strictness, tool-loop, policy, budget,
+   `--agency-only`, and `--capture-workdir` options. Remove the dead `--resume`
+   flags from `run` and `trace run`.
+5. Add resume-only repeated `--local-var`, `--global-var`, `--arg`, and
+   `--program-arg` options. Pass `programArg` to `run()` as child argv.
+6. Add spawn tests for local/default overrides, argument/global overrides,
+   `--program-arg`, `--approve`, no-policy interrupt reporting,
+   `--agency-only` compile refusal, trace footer creation, and malformed flags.
+
+## Task 5: Documentation
+
+**Files:** Add `docs/dev/runtime/resume-command.md`. Modify
+`docs/dev/runtime/checkpoint-integrity.md`, `docs/dev/runtime/rewind.md`,
+`docs/site/guide/checkpointing.md`, `CLAUDE.md`, and
+`.claude/skills/agency-runtime-docs/SKILL.md`.
+
+1. Document the child-process carrier flow, the private CLI resume binding,
+   shared restore setup, lifecycle behavior, checksum rule, sandbox parity,
+   and program-argument rule.
+2. Keep the existing public `rewindFrom(checkpoint, flatLocals, opts?)`
+   examples and document that args/globals belong to `agency resume` and the
+   internal resume request.
+3. Replace the nonexistent `saveToDisk` example. Tell users to copy the JSON
+   object printed by `printJSON`; warn that redirecting all `agency run`
+   output also captures the launch banner.
+4. Add the new dev note to both runtime indexes.
+
+## Final verification
+
+Run each command once and save output:
+
+```bash
+pnpm run typecheck 2>&1 | tee /tmp/resume-final-typecheck.txt
+pnpm run fmt:ts
+pnpm run fmt:ts:check 2>&1 | tee /tmp/resume-final-format.txt
+pnpm run lint:structure 2>&1 | tee /tmp/resume-final-lint.txt
+pnpm test:run <targeted unit files> 2>&1 | tee /tmp/resume-final-unit.txt
+pnpm run agency test js tests/agency-js/rewind-overrides 2>&1 | tee /tmp/resume-final-rewind.txt
+pnpm run agency test js tests/agency-js/resume-overrides 2>&1 | tee /tmp/resume-final-overrides.txt
+pnpm run agency test js tests/agency-js/resume-reinterrupt 2>&1 | tee /tmp/resume-final-reinterrupt.txt
+```
+
+Run the resume spawn test separately. Check its trace fixture for one header
+and a footer. Smoke-test debugger rewind because it remains the other caller.
+Review the diff against the anti-pattern catalog, then commit, push the
+`codex/agency-resume-command` branch, and open a PR against `main`.

--- a/packages/agency-lang/lib/backends/moduleFingerprint.test.ts
+++ b/packages/agency-lang/lib/backends/moduleFingerprint.test.ts
@@ -6,11 +6,12 @@ import { compileSource } from "../compiler/compile.js";
 import { sha256Text } from "../utils/hash.js";
 import { generateTypeScript } from "./typescriptGenerator.js";
 import { parseAgency } from "../parser.js";
+import { transformSync } from "esbuild";
 
 const FILE = path.join(os.tmpdir(), "agency-modfp-itest.agency");
 
 const REGISTRATION =
-  /__registerModuleFingerprint\("([^"]+)", "([0-9a-f]{64})", import\.meta\.url\);/;
+  /__registerModuleFingerprint\("([^"]+)", "([0-9a-f]{64})", import\.meta\.url\);?/;
 
 function generate(source: string): string {
   const parsed = parseAgency(source, {}, true);
@@ -56,12 +57,28 @@ describe("module fingerprint emission", () => {
     expect(changedHash![2]).not.toBe(baseHash![2]);
   });
 
-  it("compileSource programs register no fingerprint (no stable module identity)", () => {
+  it("does not mistake user text for the generated CLI entry", () => {
+    const guardText = "if (__process.argv[1] === fileURLToPath(import.meta.url)) {";
+    const code = generate(`// ${guardText}
+node main() {}`);
+
+    expect(() => transformSync(code, { loader: "ts", format: "esm" })).not.toThrow();
+    const registration = code.match(REGISTRATION);
+    expect(registration).not.toBeNull();
+    expect(code.indexOf(registration![0])).toBeLessThan(
+      code.lastIndexOf("if (__process.argv[1] === fileURLToPath(import.meta.url))"),
+    );
+  });
+
+  it("compileSource registers a fingerprint when given a stable module identity", () => {
     fs.writeFileSync(FILE, BASE, "utf-8");
-    const compiled = compileSource(BASE, { sourcePath: FILE });
+    const compiled = compileSource(BASE, {
+      sourcePath: FILE,
+      fingerprintModuleId: FILE,
+    });
     if (!compiled.success) {
       throw new Error("compile failed: " + JSON.stringify(compiled.errors));
     }
-    expect(compiled.code).not.toContain("__registerModuleFingerprint(");
+    expect(compiled.code).toContain("__registerModuleFingerprint(");
   });
 });

--- a/packages/agency-lang/lib/backends/moduleFingerprint.test.ts
+++ b/packages/agency-lang/lib/backends/moduleFingerprint.test.ts
@@ -10,7 +10,7 @@ import { parseAgency } from "../parser.js";
 const FILE = path.join(os.tmpdir(), "agency-modfp-itest.agency");
 
 const REGISTRATION =
-  /\n__registerModuleFingerprint\("([^"]+)", "([0-9a-f]{64})", import\.meta\.url\);\n$/;
+  /__registerModuleFingerprint\("([^"]+)", "([0-9a-f]{64})", import\.meta\.url\);/;
 
 function generate(source: string): string {
   const parsed = parseAgency(source, {}, true);
@@ -32,15 +32,18 @@ def double(n: number): number {
 `;
 
 describe("module fingerprint emission", () => {
-  it("appends a registration whose hash covers the printed output before it", () => {
+  it("registers before the CLI entry and hashes the output without the registration", () => {
     const code = generate(BASE);
     const registration = code.match(REGISTRATION);
     if (!registration) {
       throw new Error("no __registerModuleFingerprint emission found");
     }
     expect(registration[1]).toBe("mod.agency");
-    const withoutRegistration = code.slice(0, code.length - registration[0].length);
+    const withoutRegistration = code.replace(`${registration[0]}\n`, "");
     expect(registration[2]).toBe(sha256Text(withoutRegistration));
+    expect(code.indexOf(registration[0])).toBeLessThan(
+      code.indexOf("if (__process.argv[1] === fileURLToPath(import.meta.url))"),
+    );
   });
 
   it("identical input generates identical bytes (incremental emit stays byte-identical)", () => {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -538,7 +538,8 @@ node main(first: string, second: string) {
 }
 `);
 
-    expect(output).toContain("await main(undefined, undefined, initialState)");
+    expect(output).toContain("runMain: () => main(undefined, undefined, initialState)");
+    expect(output).toContain("resume: __resumeFromCheckpoint");
     expect(output).not.toContain("__process.argv[2]");
     expect(output).not.toContain("main() takes");
   });

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -4494,7 +4494,18 @@ export class TypeScriptBuilder {
                     data: ts.obj({}),
                   }),
                 ),
-                ts.varDecl("const", "__result", ts.await(ts.call(ts.id("main"), mainCallArgs))),
+                ts.varDecl(
+                  "const",
+                  "__result",
+                  ts.await(
+                    ts.call(ts.id("runCliEntry"), [
+                      ts.obj({
+                        runMain: ts.arrowFn([], ts.call(ts.id("main"), mainCallArgs)),
+                        resume: ts.id("__resumeFromCheckpoint"),
+                      }),
+                    ]),
+                  ),
+                ),
                 // Running `main` directly from the CLI: interrupts that no
                 // handler settled have surfaced to the user. resolveCliInterrupts
                 // is that user endpoint — under a run policy it decides each one

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -499,7 +499,7 @@ export class TypeScriptBuilder {
 
   // ------- Main entry point -------
 
-  build(program: AgencyProgram): TsNode {
+  build(program: AgencyProgram, moduleFingerprint?: { moduleId: string; hash: string }): TsNode {
     // A template is not a program. Refuse before generating anything, and
     // name every unfilled hole — not just the first one met — so the
     // message tells the user the full fill they owe.
@@ -593,6 +593,7 @@ export class TypeScriptBuilder {
       registryModuleId: this.initPlan?.registryModuleId,
       staticLocalOrder: this.initPlan?.staticLocalOrder,
       globalLocalOrder: this.initPlan?.globalLocalOrder,
+      moduleFingerprint,
     });
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -386,6 +386,7 @@ export type AssembleSectionsOpts = {
    */
   staticLocalOrder?: string[];
   globalLocalOrder?: string[];
+  moduleFingerprint?: { moduleId: string; hash: string };
 };
 
 /**
@@ -419,6 +420,16 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
 
   if (opts.generatedBuiltins.trim() !== "") {
     sections.push(ts.raw(opts.generatedBuiltins));
+  }
+
+  if (opts.moduleFingerprint !== undefined) {
+    sections.push(
+      ts.call(ts.id("__registerModuleFingerprint"), [
+        ts.str(opts.moduleFingerprint.moduleId),
+        ts.str(opts.moduleFingerprint.hash),
+        ts.raw("import.meta.url"),
+      ]),
+    );
   }
 
   if (opts.toolRegistrations.length > 0) {

--- a/packages/agency-lang/lib/backends/typescriptGenerator.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator.ts
@@ -70,27 +70,14 @@ export function generateTypeScript(
   const compilationUnit = info ?? buildCompilationUnit(program);
   const preprocessor = new TypescriptPreprocessor(program, config, compilationUnit);
   const preprocessedProgram = preprocessor.preprocess();
-  const builder = new TypeScriptBuilder(config, compilationUnit, moduleId, outputFile, initPlan);
-  const ir = builder.build(preprocessedProgram);
-  const code = printTs(ir);
+  const build = (moduleFingerprint?: { moduleId: string; hash: string }): string => {
+    const builder = new TypeScriptBuilder(config, compilationUnit, moduleId, outputFile, initPlan);
+    return printTs(builder.build(preprocessedProgram, moduleFingerprint));
+  };
+  const code = build();
   if (!fingerprint) {
     return code;
   }
-  // Fingerprint the PRINTED output: it is what resume replays into, so it
-  // covers splice expansion, templates, and the compiler itself. Hash before
-  // appending the registration (a value cannot cover itself). The emitted
-  // bytes carry no timestamp — the registry derives "compiled at" from the
-  // artifact's mtime — so identical input emits identical bytes and
-  // incremental emit stays byte-identical to a force emit.
   const hash = sha256Text(code);
-  const registration = `__registerModuleFingerprint(${JSON.stringify(moduleId)}, ${JSON.stringify(hash)}, import.meta.url);`;
-  const cliEntry = "if (__process.argv[1] === fileURLToPath(import.meta.url)) {";
-  const cliEntryIndex = code.indexOf(cliEntry);
-  if (cliEntryIndex === -1) {
-    return `${code}\n${registration}\n`;
-  }
-  // The entry module can create checkpoints while its top-level await is
-  // running. Register before that run starts so those checkpoints record this
-  // module's identity instead of silently omitting it.
-  return `${code.slice(0, cliEntryIndex)}${registration}\n${code.slice(cliEntryIndex)}`;
+  return build({ moduleId, hash });
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator.ts
@@ -83,8 +83,14 @@ export function generateTypeScript(
   // artifact's mtime — so identical input emits identical bytes and
   // incremental emit stays byte-identical to a force emit.
   const hash = sha256Text(code);
-  return (
-    code +
-    `\n__registerModuleFingerprint(${JSON.stringify(moduleId)}, ${JSON.stringify(hash)}, import.meta.url);\n`
-  );
+  const registration = `__registerModuleFingerprint(${JSON.stringify(moduleId)}, ${JSON.stringify(hash)}, import.meta.url);`;
+  const cliEntry = "if (__process.argv[1] === fileURLToPath(import.meta.url)) {";
+  const cliEntryIndex = code.indexOf(cliEntry);
+  if (cliEntryIndex === -1) {
+    return `${code}\n${registration}\n`;
+  }
+  // The entry module can create checkpoints while its top-level await is
+  // running. Register before that run starts so those checkpoints record this
+  // module's identity instead of silently omitting it.
+  return `${code.slice(0, cliEntryIndex)}${registration}\n${code.slice(cliEntryIndex)}`;
 }

--- a/packages/agency-lang/lib/cli/childEnv.test.ts
+++ b/packages/agency-lang/lib/cli/childEnv.test.ts
@@ -28,18 +28,20 @@ describe("withRootCarriers", () => {
     const inherited = {
       AGENCY_RESUME_FILE: "/stale/checkpoint.json",
       AGENCY_RESUME_OVERRIDES: '{"locals":{"stale":true}}',
+      AGENCY_RESUME_FORCE: "1",
       PATH: "/bin",
     };
 
     expect(withRootCarriers(inherited, {})).toEqual({ PATH: "/bin" });
     expect(
       withRootCarriers(inherited, {
-        resume: { checkpointFile: "/new/checkpoint.json", overridesJson: "{}" },
+        resume: { checkpointFile: "/new/checkpoint.json", overridesJson: "{}", force: true },
       }),
     ).toEqual({
       PATH: "/bin",
       AGENCY_RESUME_FILE: "/new/checkpoint.json",
       AGENCY_RESUME_OVERRIDES: "{}",
+      AGENCY_RESUME_FORCE: "1",
     });
   });
 });

--- a/packages/agency-lang/lib/cli/childEnv.test.ts
+++ b/packages/agency-lang/lib/cli/childEnv.test.ts
@@ -23,4 +23,23 @@ describe("withRootCarriers", () => {
       AGENCY_MAX_COST: "5",
     });
   });
+
+  test("clears stale resume carriers and sets both only for resume", () => {
+    const inherited = {
+      AGENCY_RESUME_FILE: "/stale/checkpoint.json",
+      AGENCY_RESUME_OVERRIDES: '{"locals":{"stale":true}}',
+      PATH: "/bin",
+    };
+
+    expect(withRootCarriers(inherited, {})).toEqual({ PATH: "/bin" });
+    expect(
+      withRootCarriers(inherited, {
+        resume: { checkpointFile: "/new/checkpoint.json", overridesJson: "{}" },
+      }),
+    ).toEqual({
+      PATH: "/bin",
+      AGENCY_RESUME_FILE: "/new/checkpoint.json",
+      AGENCY_RESUME_OVERRIDES: "{}",
+    });
+  });
 });

--- a/packages/agency-lang/lib/cli/childEnv.ts
+++ b/packages/agency-lang/lib/cli/childEnv.ts
@@ -10,12 +10,16 @@ import {
   AGENCY_RUN_POLICY,
   AGENCY_RUN_POLICY_INTERACTIVE,
   AGENCY_RUN_POLICY_INTERACTIVE_ON,
+  AGENCY_RESUME_FILE,
+  AGENCY_RESUME_OVERRIDES,
 } from "@/constants.js";
+import type { ResumeCarrier } from "./resumeCarrier.js";
 
 export type RootCarriers = {
   policy?: { policyJson: string; interactive?: boolean };
   /** `resolveBudget`'s shape: dollars and milliseconds as strings. */
   budget?: { maxCost?: string; maxTime?: string };
+  resume?: ResumeCarrier;
 };
 
 export function withRootCarriers(
@@ -27,6 +31,8 @@ export function withRootCarriers(
   delete out[AGENCY_RUN_POLICY_INTERACTIVE];
   delete out[AGENCY_MAX_COST];
   delete out[AGENCY_MAX_TIME];
+  delete out[AGENCY_RESUME_FILE];
+  delete out[AGENCY_RESUME_OVERRIDES];
   if (carriers.policy !== undefined) {
     out[AGENCY_RUN_POLICY] = carriers.policy.policyJson;
     if (carriers.policy.interactive)
@@ -34,5 +40,9 @@ export function withRootCarriers(
   }
   if (carriers.budget?.maxCost !== undefined) out[AGENCY_MAX_COST] = carriers.budget.maxCost;
   if (carriers.budget?.maxTime !== undefined) out[AGENCY_MAX_TIME] = carriers.budget.maxTime;
+  if (carriers.resume !== undefined) {
+    out[AGENCY_RESUME_FILE] = carriers.resume.checkpointFile;
+    out[AGENCY_RESUME_OVERRIDES] = carriers.resume.overridesJson;
+  }
   return out;
 }

--- a/packages/agency-lang/lib/cli/childEnv.ts
+++ b/packages/agency-lang/lib/cli/childEnv.ts
@@ -11,6 +11,7 @@ import {
   AGENCY_RUN_POLICY_INTERACTIVE,
   AGENCY_RUN_POLICY_INTERACTIVE_ON,
   AGENCY_RESUME_FILE,
+  AGENCY_RESUME_FORCE,
   AGENCY_RESUME_OVERRIDES,
 } from "@/constants.js";
 import type { ResumeCarrier } from "./resumeCarrier.js";
@@ -33,6 +34,7 @@ export function withRootCarriers(
   delete out[AGENCY_MAX_TIME];
   delete out[AGENCY_RESUME_FILE];
   delete out[AGENCY_RESUME_OVERRIDES];
+  delete out[AGENCY_RESUME_FORCE];
   if (carriers.policy !== undefined) {
     out[AGENCY_RUN_POLICY] = carriers.policy.policyJson;
     if (carriers.policy.interactive)
@@ -43,6 +45,9 @@ export function withRootCarriers(
   if (carriers.resume !== undefined) {
     out[AGENCY_RESUME_FILE] = carriers.resume.checkpointFile;
     out[AGENCY_RESUME_OVERRIDES] = carriers.resume.overridesJson;
+    if (carriers.resume.force) {
+      out[AGENCY_RESUME_FORCE] = "1";
+    }
   }
   return out;
 }

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import { RunStrategy } from "../importStrategy.js";
 import { compileAgencyOnly } from "../compiler/compileSandboxed.js";
 import { withRootCarriers } from "./childEnv.js";
+import type { ResumeCarrier } from "./resumeCarrier.js";
 import {} from "@/constants.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -274,7 +275,7 @@ export function run(
   config: AgencyConfig,
   inputFile: string,
   outputFile?: string,
-  resumeFile?: string,
+  resume?: ResumeCarrier,
   runPolicy?: { policyJson: string; interactive: boolean },
   budget?: { maxCost?: string; maxTime?: string },
   /** Forwarded to the compiled program's argv (positions 2+), for the program
@@ -309,7 +310,7 @@ export function run(
   console.log(`Running ${output}...`);
   console.log("---");
 
-  const env = withRootCarriers(process.env, { policy: runPolicy, budget });
+  const env = withRootCarriers(process.env, { policy: runPolicy, budget, resume });
   const captured = capture === undefined ? undefined : prepareCapture(capture.runDir);
   env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(
     runChildOverrides({
@@ -319,8 +320,6 @@ export function run(
     }),
   );
   if (captured !== undefined) env[TRACE_ID_ENV] = captured.traceId;
-  if (resumeFile) env.AGENCY_RESUME_FILE = resumeFile;
-
   // Use process.execPath so the child runs under the same Node as the CLI,
   // and pass our resolver shim so the compiled output's `import "agency-lang"`
   // succeeds even when the CLI is installed globally.

--- a/packages/agency-lang/lib/cli/resume.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/resume.spawn.test.ts
@@ -1,0 +1,176 @@
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const CLI = path.resolve("dist/scripts/agency.js");
+
+const SOURCE = `import { args } from "std::system"
+
+let status = "old"
+
+node main(name: string = "before") {
+  let mood = "sad"
+  const id = checkpoint()
+  print("CHECKPOINT_BEGIN")
+  printJSON(getCheckpoint(id))
+  print("CHECKPOINT_END")
+  const argv = args()
+  print("VALUES:" + mood + ":" + name + ":" + status + ":" + argv[0])
+}
+`;
+
+const REINTERRUPT_SOURCE = `effect test::gate { label: string }
+
+node main() {
+  const id = checkpoint()
+  print("CHECKPOINT_BEGIN")
+  printJSON(getCheckpoint(id))
+  print("CHECKPOINT_END")
+  interrupt test::gate("pause", { label: "again" })
+  print("AFTER_GATE")
+}
+`;
+
+function checkpointFrom(output: string): string {
+  const match = output.match(/CHECKPOINT_BEGIN\s*([\s\S]*?)\s*CHECKPOINT_END/);
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+function removeTemp(dir: string): void {
+  const root = realpathSync(process.cwd());
+  const resolved = realpathSync(dir);
+  if (
+    path.dirname(resolved) === root &&
+    path.basename(resolved).startsWith(".agency-resume-spawn-")
+  ) {
+    rmSync(resolved, { recursive: true, force: true });
+  }
+}
+
+async function invoke(dir: string, args: string[]) {
+  try {
+    const result = await execFileAsync(process.execPath, [CLI, ...args], {
+      cwd: dir,
+      timeout: 60_000,
+    });
+    return { ...result, code: 0 };
+  } catch (error: any) {
+    return { stdout: error.stdout ?? "", stderr: error.stderr ?? "", code: error.code ?? 1 };
+  }
+}
+
+describe.skipIf(!existsSync(CLI))("agency resume (end-to-end)", () => {
+  it("resumes with all override buckets, program argv, and a complete trace", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE);
+      const fresh = await invoke(dir, ["run", "--trace-file", "resume.trace", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+      rmSync(path.join(dir, "resume.trace"));
+
+      const resumed = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--local-var",
+        "mood=happy",
+        "--arg",
+        'name="Ada"',
+        "--global-var",
+        'status="ready"',
+        "--program-arg",
+        "hello",
+        "--trace-file",
+        "resume.trace",
+      ]);
+
+      expect(resumed.code, resumed.stderr).toBe(0);
+      expect(resumed.stdout).toContain("VALUES:happy:Ada:ready:hello");
+      const trace = readFileSync(path.join(dir, "resume.trace"), "utf8");
+      expect(trace).toMatch(/"type":"header"/);
+      expect(trace).toMatch(/"type":"footer"/);
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("surfaces another interrupt, or handles it with the resumed root policy", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), REINTERRUPT_SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"]);
+      expect(fresh.code).not.toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+
+      const unhandled = await invoke(dir, ["resume", "checkpoint.json", "agent.agency"]);
+      expect(unhandled.code).not.toBe(0);
+      expect(unhandled.stderr).toMatch(/was not handled/i);
+
+      const approved = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--approve",
+        "test::gate",
+      ]);
+      expect(approved.code, approved.stderr).toBe(0);
+      expect(approved.stdout).toContain("AFTER_GATE");
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("preserves --agency-only compilation refusal", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "checkpoint.json"), "{}");
+      writeFileSync(path.join(dir, "helper.js"), "export const value = 1;\n");
+      writeFileSync(
+        path.join(dir, "agent.agency"),
+        'import { value } from "./helper.js"\nnode main() { return value }\n',
+      );
+
+      const result = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--agency-only",
+      ]);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toMatch(/agency-only compile refused/i);
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("refuses a checkpoint after the Agency source changes", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE.replace("VALUES:", "CHANGED:"));
+
+      const resumed = await invoke(dir, ["resume", "checkpoint.json", "agent.agency"]);
+
+      expect(resumed.code).not.toBe(0);
+      expect(resumed.stderr).toMatch(/code .* has changed/i);
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+});

--- a/packages/agency-lang/lib/cli/resume.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/resume.spawn.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -41,6 +42,38 @@ node main() {
 }
 `;
 
+const FUNCTION_SOURCE = `def greet(name: string): string {
+  const id = checkpoint()
+  print("CHECKPOINT_BEGIN")
+  printJSON(getCheckpoint(id))
+  print("CHECKPOINT_END")
+  return name
+}
+
+node main() {
+  const greeting = greet("before")
+  print("FUNCTION_VALUE:" + greeting)
+}
+`;
+
+const NESTED_FUNCTION_SOURCE = `def inner(name: string): string {
+  const id = checkpoint()
+  print("CHECKPOINT_BEGIN")
+  printJSON(getCheckpoint(id))
+  print("CHECKPOINT_END")
+  return name
+}
+
+def outer(name: string): string {
+  return inner("inner-before")
+}
+
+node main() {
+  const greeting = outer("outer-before")
+  print("NESTED_FUNCTION_VALUE:" + greeting)
+}
+`;
+
 function checkpointFrom(output: string): string {
   const match = output.match(/CHECKPOINT_BEGIN\s*([\s\S]*?)\s*CHECKPOINT_END/);
   expect(match).not.toBeNull();
@@ -58,11 +91,12 @@ function removeTemp(dir: string): void {
   }
 }
 
-async function invoke(dir: string, args: string[]) {
+async function invoke(dir: string, args: string[], env?: NodeJS.ProcessEnv) {
   try {
     const result = await execFileAsync(process.execPath, [CLI, ...args], {
       cwd: dir,
       timeout: 60_000,
+      env: { ...process.env, ...env },
     });
     return { ...result, code: 0 };
   } catch (error: any) {
@@ -132,6 +166,105 @@ describe.skipIf(!existsSync(CLI))("agency resume (end-to-end)", () => {
     }
   }, 120_000);
 
+  it("applies an argument override to a paused function", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), FUNCTION_SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+
+      const resumed = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--arg",
+        'name="after"',
+      ]);
+
+      expect(resumed.code, resumed.stderr).toBe(0);
+      expect(resumed.stdout).toContain("FUNCTION_VALUE:after");
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("applies an argument override to the deepest paused function", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), NESTED_FUNCTION_SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+
+      const resumed = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--arg",
+        'name="after"',
+      ]);
+
+      expect(resumed.code, resumed.stderr).toBe(0);
+      expect(resumed.stdout).toContain("NESTED_FUNCTION_VALUE:after");
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("requires force to resume a checkpoint with an invalid signature", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    const env = { AGENCY_CHECKPOINT_KEY: "a".repeat(32) };
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"], env);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      const checkpoint = JSON.parse(checkpointFrom(fresh.stdout));
+      checkpoint.stack.stack.at(-1).locals.mood = "forced";
+      writeFileSync(path.join(dir, "checkpoint.json"), JSON.stringify(checkpoint));
+
+      const refused = await invoke(dir, ["resume", "checkpoint.json", "agent.agency"], env);
+      expect(refused.code).not.toBe(0);
+      expect(refused.stderr).toMatch(/checksum verification/i);
+
+      const forced = await invoke(
+        dir,
+        ["resume", "checkpoint.json", "agent.agency", "--force"],
+        env,
+      );
+      expect(forced.code, forced.stderr).toBe(0);
+      expect(forced.stdout).toContain("VALUES:forced:before:old:null");
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("keeps capture output under the capture trace id", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE);
+      const fresh = await invoke(dir, ["run", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+
+      const resumed = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--capture-workdir",
+        "captures",
+      ]);
+
+      expect(resumed.code, resumed.stderr).toBe(0);
+      const match = resumed.stdout.match(/Captured trace ([^ ]+) into (.+)\n?/);
+      expect(match).not.toBeNull();
+      expect(readdirSync(path.join(dir, "captures"))).toEqual([match![1]]);
+      expect(path.basename(match![2].trim())).toBe(match![1]);
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
   it("preserves --agency-only compilation refusal", async () => {
     const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
     try {
@@ -166,6 +299,38 @@ describe.skipIf(!existsSync(CLI))("agency resume (end-to-end)", () => {
       writeFileSync(path.join(dir, "agent.agency"), SOURCE.replace("VALUES:", "CHANGED:"));
 
       const resumed = await invoke(dir, ["resume", "checkpoint.json", "agent.agency"]);
+
+      expect(resumed.code).not.toBe(0);
+      expect(resumed.stderr).toMatch(/code .* has changed/i);
+    } finally {
+      removeTemp(dir);
+    }
+  }, 120_000);
+
+  it("refuses changed Agency source in agency-only mode", async () => {
+    const dir = mkdtempSync(path.join(process.cwd(), ".agency-resume-spawn-"));
+    try {
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE);
+      const fresh = await invoke(dir, ["run", "--agency-only", "agent.agency"]);
+      expect(fresh.code, fresh.stderr).toBe(0);
+      writeFileSync(path.join(dir, "checkpoint.json"), checkpointFrom(fresh.stdout));
+
+      const unchanged = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--agency-only",
+      ]);
+      expect(unchanged.code, unchanged.stderr).toBe(0);
+
+      writeFileSync(path.join(dir, "agent.agency"), SOURCE.replace("VALUES:", "CHANGED:"));
+
+      const resumed = await invoke(dir, [
+        "resume",
+        "checkpoint.json",
+        "agent.agency",
+        "--agency-only",
+      ]);
 
       expect(resumed.code).not.toBe(0);
       expect(resumed.stderr).toMatch(/code .* has changed/i);

--- a/packages/agency-lang/lib/cli/resumeCarrier.test.ts
+++ b/packages/agency-lang/lib/cli/resumeCarrier.test.ts
@@ -15,17 +15,26 @@ describe("resolveResumeCarrier", () => {
     dirs.push(dir);
     writeFileSync(path.join(dir, "cp.json"), "{}");
 
-    expect(resolveResumeCarrier("cp.json", { locals: { x: 1 } }, dir)).toEqual({
+    expect(resolveResumeCarrier("cp.json", { locals: { x: 1 } }, false, dir)).toEqual({
       checkpointFile: path.join(dir, "cp.json"),
       overridesJson: JSON.stringify({ locals: { x: 1 } }),
+      force: false,
     });
+  });
+
+  it("carries the force choice", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "agency-resume-carrier-"));
+    dirs.push(dir);
+    writeFileSync(path.join(dir, "cp.json"), "{}");
+
+    expect(resolveResumeCarrier("cp.json", {}, true, dir).force).toBe(true);
   });
 
   it("rejects missing files and directories", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "agency-resume-carrier-"));
     dirs.push(dir);
-    expect(() => resolveResumeCarrier("missing.json", {}, dir)).toThrow("does not exist");
-    expect(() => resolveResumeCarrier(".", {}, dir)).toThrow("is not a file");
+    expect(() => resolveResumeCarrier("missing.json", {}, false, dir)).toThrow("does not exist");
+    expect(() => resolveResumeCarrier(".", {}, false, dir)).toThrow("is not a file");
   });
 
   it("refuses checkpoint symlinks", () => {
@@ -34,6 +43,8 @@ describe("resolveResumeCarrier", () => {
     writeFileSync(path.join(dir, "target.json"), "{}");
     symlinkSync("target.json", path.join(dir, "checkpoint.json"));
 
-    expect(() => resolveResumeCarrier("checkpoint.json", {}, dir)).toThrow("must not be a symlink");
+    expect(() => resolveResumeCarrier("checkpoint.json", {}, false, dir)).toThrow(
+      "must not be a symlink",
+    );
   });
 });

--- a/packages/agency-lang/lib/cli/resumeCarrier.test.ts
+++ b/packages/agency-lang/lib/cli/resumeCarrier.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveResumeCarrier } from "./resumeCarrier.js";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolveResumeCarrier", () => {
+  it("resolves the checkpoint path and serializes overrides", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "agency-resume-carrier-"));
+    dirs.push(dir);
+    writeFileSync(path.join(dir, "cp.json"), "{}");
+
+    expect(resolveResumeCarrier("cp.json", { locals: { x: 1 } }, dir)).toEqual({
+      checkpointFile: path.join(dir, "cp.json"),
+      overridesJson: JSON.stringify({ locals: { x: 1 } }),
+    });
+  });
+
+  it("rejects missing files and directories", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "agency-resume-carrier-"));
+    dirs.push(dir);
+    expect(() => resolveResumeCarrier("missing.json", {}, dir)).toThrow("does not exist");
+    expect(() => resolveResumeCarrier(".", {}, dir)).toThrow("is not a file");
+  });
+
+  it("refuses checkpoint symlinks", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "agency-resume-carrier-"));
+    dirs.push(dir);
+    writeFileSync(path.join(dir, "target.json"), "{}");
+    symlinkSync("target.json", path.join(dir, "checkpoint.json"));
+
+    expect(() => resolveResumeCarrier("checkpoint.json", {}, dir)).toThrow("must not be a symlink");
+  });
+});

--- a/packages/agency-lang/lib/cli/resumeCarrier.ts
+++ b/packages/agency-lang/lib/cli/resumeCarrier.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ResumeOverrides } from "../runtime/resumeSetup.js";
+
+export type ResumeCarrier = {
+  checkpointFile: string;
+  overridesJson: string;
+};
+
+export function resolveResumeCarrier(
+  checkpointFile: string,
+  overrides: ResumeOverrides,
+  cwd = process.cwd(),
+): ResumeCarrier {
+  const resolved = path.resolve(cwd, checkpointFile);
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(resolved);
+  } catch {
+    throw new Error(`Checkpoint file does not exist: ${resolved}`);
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Checkpoint path must not be a symlink: ${resolved}`);
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Checkpoint path is not a file: ${resolved}`);
+  }
+  return { checkpointFile: resolved, overridesJson: JSON.stringify(overrides) };
+}

--- a/packages/agency-lang/lib/cli/resumeCarrier.ts
+++ b/packages/agency-lang/lib/cli/resumeCarrier.ts
@@ -5,11 +5,13 @@ import type { ResumeOverrides } from "../runtime/resumeSetup.js";
 export type ResumeCarrier = {
   checkpointFile: string;
   overridesJson: string;
+  force: boolean;
 };
 
 export function resolveResumeCarrier(
   checkpointFile: string,
   overrides: ResumeOverrides,
+  force: boolean,
   cwd = process.cwd(),
 ): ResumeCarrier {
   const resolved = path.resolve(cwd, checkpointFile);
@@ -25,5 +27,5 @@ export function resolveResumeCarrier(
   if (!stats.isFile()) {
     throw new Error(`Checkpoint path is not a file: ${resolved}`);
   }
-  return { checkpointFile: resolved, overridesJson: JSON.stringify(overrides) };
+  return { checkpointFile: resolved, overridesJson: JSON.stringify(overrides), force };
 }

--- a/packages/agency-lang/lib/cli/resumeOverrides.test.ts
+++ b/packages/agency-lang/lib/cli/resumeOverrides.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { parseResumeOverrides } from "./resumeOverrides.js";
+
+describe("parseResumeOverrides", () => {
+  it("parses JSON values and falls back to strings", () => {
+    const result = parseResumeOverrides({
+      localVar: ["count=2", "label=hello"],
+      arg: ["enabled=true"],
+      globalVar: ['config={"mode":"safe"}'],
+    });
+
+    expect(result).toEqual({
+      locals: { count: 2, label: "hello" },
+      args: { enabled: true },
+      globals: { config: { mode: "safe" } },
+    });
+    expect(Object.getPrototypeOf(result.locals!)).toBeNull();
+  });
+
+  it("keeps equals signs after the first one", () => {
+    expect(parseResumeOverrides({ localVar: ["url=a=b"] }).locals).toEqual({ url: "a=b" });
+  });
+
+  it("rejects malformed assignments", () => {
+    expect(() => parseResumeOverrides({ arg: ["missing"] })).toThrow("--arg expects name=value");
+    expect(() => parseResumeOverrides({ globalVar: ["=value"] })).toThrow(
+      "--global-var expects name=value",
+    );
+    expect(() => parseResumeOverrides({ localVar: ["__proto__=polluted"] })).toThrow(
+      "invalid Agency variable name",
+    );
+  });
+});

--- a/packages/agency-lang/lib/cli/resumeOverrides.ts
+++ b/packages/agency-lang/lib/cli/resumeOverrides.ts
@@ -1,0 +1,39 @@
+import type { ResumeOverrides } from "../runtime/resumeSetup.js";
+
+export type ResumeOverrideFlags = {
+  localVar?: string[];
+  arg?: string[];
+  globalVar?: string[];
+};
+
+function parseValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function parseAssignments(values: string[] | undefined, flag: string): Record<string, unknown> {
+  const result = Object.create(null) as Record<string, unknown>;
+  for (const assignment of values ?? []) {
+    const separator = assignment.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`${flag} expects name=value (got "${assignment}")`);
+    }
+    const name = assignment.slice(0, separator);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || name === "__proto__") {
+      throw new Error(`${flag} has an invalid Agency variable name: "${name}"`);
+    }
+    result[name] = parseValue(assignment.slice(separator + 1));
+  }
+  return result;
+}
+
+export function parseResumeOverrides(flags: ResumeOverrideFlags): ResumeOverrides {
+  return {
+    locals: parseAssignments(flags.localVar, "--local-var"),
+    args: parseAssignments(flags.arg, "--arg"),
+    globals: parseAssignments(flags.globalVar, "--global-var"),
+  };
+}

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -4,7 +4,7 @@
  */
 import { AgencyConfig } from "@/config.js";
 import { AgencyProgram, generateTypeScript } from "@/index.js";
-import { initPlanForModule } from "@/backends/typescriptGenerator.js";
+import { initPlanForModule, type InitPlanForModule } from "@/backends/typescriptGenerator.js";
 import { resolveImports } from "@/preprocessors/importResolver.js";
 import { resolveReExports } from "@/preprocessors/resolveReExports.js";
 import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
@@ -46,6 +46,33 @@ type CompileFailure = {
 
 export type CompileResult = CompileSuccess | CompileFailure;
 
+function useStableModuleIds(
+  plan: InitPlanForModule,
+  mirrorModuleId: string,
+  stableModuleId: string,
+): InitPlanForModule {
+  const remap = (moduleId: string): string =>
+    path.resolve(
+      path.dirname(stableModuleId),
+      path.relative(path.dirname(mirrorModuleId), moduleId),
+    );
+  const remapAwaitModules = (modules: InitPlanForModule["staticAwaitModules"]) =>
+    modules.map((module) => ({ ...module, sourceModuleId: remap(module.sourceModuleId) }));
+
+  return {
+    ...plan,
+    registryModuleId: stableModuleId,
+    staticAwaitModules: remapAwaitModules(plan.staticAwaitModules),
+    globalAwaitModules: remapAwaitModules(plan.globalAwaitModules),
+    resolveImportedName: (localName) => {
+      const resolved = plan.resolveImportedName(localName);
+      return resolved === null
+        ? null
+        : { ...resolved, sourceModuleId: remap(resolved.sourceModuleId) };
+    },
+  };
+}
+
 // Options accepted by compileSource. Mostly the standard AgencyConfig that
 // the rest of the pipeline takes, plus one compileSource-specific knob:
 // `imports`. We keep `imports` out of the global AgencyConfig because it's
@@ -71,6 +98,9 @@ export type CompileSourceOptions = AgencyConfig & {
    * ignored (pass the file's contents for clarity, but the disk file wins).
    */
   sourcePath?: string;
+  /** Stable module identity for checkpoint fingerprints. Omit for ephemeral
+   * subprocess programs whose generated module id is intentionally random. */
+  fingerprintModuleId?: string;
 };
 
 // Walk every import in the program and reject anything that fails the
@@ -106,6 +136,7 @@ export type { TypeCheckDiagnostic, TypeCheckReport } from "./typecheck.js";
 
 export function compileSource(source: string, config: CompileSourceOptions): CompileResult {
   const moduleId = `agency_${nanoid()}`;
+  const generatedModuleId = config.fingerprintModuleId ?? moduleId;
   // SymbolTable.build() walks the file system from the source's path to resolve
   // imports. With a caller-supplied sourcePath (the file is already on disk
   // beside its siblings), compile at that path so relative `.agency` imports
@@ -223,14 +254,19 @@ export function compileSource(source: string, config: CompileSourceOptions): Com
 
     // 7. Generate TypeScript
     const outputPath = path.join(os.tmpdir(), `${moduleId}.js`);
-    const initPlan = initPlanForModule(closure, syntheticPath);
+    const mirrorInitPlan = initPlanForModule(closure, syntheticPath);
+    const initPlan =
+      config.fingerprintModuleId === undefined
+        ? mirrorInitPlan
+        : useStableModuleIds(mirrorInitPlan, syntheticPath, config.fingerprintModuleId);
     const generatedCode = generateTypeScript(
       liftedProgram,
       config,
       info,
-      moduleId,
+      generatedModuleId,
       outputPath,
       initPlan,
+      config.fingerprintModuleId !== undefined,
     );
 
     // 8. Transpile TS → JS

--- a/packages/agency-lang/lib/compiler/compileSandboxed.ts
+++ b/packages/agency-lang/lib/compiler/compileSandboxed.ts
@@ -19,12 +19,16 @@ export type CompileSandboxedArgs = {
   /** Enforce the reviewed JS-globals allowlist. Only `--agency-only` sets this;
    *  the trusted runtime fork path leaves it off. See compileValidatedClosure. */
   enforceJsGlobals?: boolean;
+  fingerprintModuleIds?: boolean;
 };
 
 export function compileSandboxed(args: CompileSandboxedArgs): CompileResult {
   try {
     const closure = validateClosure({ entry: args.entry, dir: args.dir });
-    return compileValidatedClosure(closure, { enforceJsGlobals: args.enforceJsGlobals });
+    return compileValidatedClosure(closure, {
+      enforceJsGlobals: args.enforceJsGlobals,
+      fingerprintModuleIds: args.fingerprintModuleIds,
+    });
   } catch (e) {
     if (e instanceof ClosureValidationError) {
       return { success: false, errors: e.violations };
@@ -45,6 +49,7 @@ export function compileAgencyOnly(sourceFile: string): AgencyOnlyCompile {
     entry: { file: path.basename(absolute) },
     dir,
     enforceJsGlobals: true,
+    fingerprintModuleIds: true,
   });
   if (!result.success) return { ok: false, errors: result.errors };
   for (const [relPath, code] of Object.entries(result.modules ?? {})) {

--- a/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileValidatedClosure.ts
@@ -25,6 +25,7 @@ export type CompileValidatedClosureOptions = {
    *  (`std::agency.run`) shares this compile but is trusted-context code that
    *  may name JS globals, so it leaves this off. */
   enforceJsGlobals?: boolean;
+  fingerprintModuleIds?: boolean;
 };
 
 export function compileValidatedClosure(
@@ -38,7 +39,8 @@ export function compileValidatedClosure(
     let entrySource = "";
     let entryMirrorPath = "";
     let entryRelPath = "";
-    const mirrored: { relPath: string; source: string; mirrorPath: string }[] = [];
+    const mirrored: { moduleId: string; relPath: string; source: string; mirrorPath: string }[] =
+      [];
     for (const [moduleId, mod] of Object.entries(data.modules)) {
       const target = path.join(mirrorRoot, ...mod.relPath.split(path.posix.sep));
       fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -48,7 +50,7 @@ export function compileValidatedClosure(
         entryMirrorPath = target;
         entryRelPath = mod.relPath;
       } else {
-        mirrored.push({ relPath: mod.relPath, source: mod.source, mirrorPath: target });
+        mirrored.push({ moduleId, relPath: mod.relPath, source: mod.source, mirrorPath: target });
       }
     }
     if (entryMirrorPath === "") {
@@ -78,6 +80,7 @@ export function compileValidatedClosure(
     const entryResult = compileSource(entrySource, {
       ...sandboxOptions,
       sourcePath: entryMirrorPath,
+      fingerprintModuleId: options.fingerprintModuleIds ? data.entryModuleId : undefined,
     });
     if (!entryResult.success) return entryResult;
     // The entry's generated JS imports each local module by relative path
@@ -89,6 +92,7 @@ export function compileValidatedClosure(
       const result = compileSource(mod.source, {
         ...sandboxOptions,
         sourcePath: mod.mirrorPath,
+        fingerprintModuleId: options.fingerprintModuleIds ? mod.moduleId : undefined,
       });
       if (!result.success) {
         return {

--- a/packages/agency-lang/lib/constants.ts
+++ b/packages/agency-lang/lib/constants.ts
@@ -94,6 +94,11 @@ export const AGENCY_RUN_POLICY_INTERACTIVE_ON = "1";
 export const AGENCY_MAX_COST = "AGENCY_MAX_COST";
 export const AGENCY_MAX_TIME = "AGENCY_MAX_TIME";
 
+/** Absolute checkpoint path and serialized override buckets carried from
+ * `agency resume` to the generated child entry. */
+export const AGENCY_RESUME_FILE = "AGENCY_RESUME_FILE";
+export const AGENCY_RESUME_OVERRIDES = "AGENCY_RESUME_OVERRIDES";
+
 /** Process exit code when a top-level cost/time budget is exceeded. Distinct
  *  from 1 (generic failure) and 2 (usage error). */
 export const EXIT_CODE_BUDGET_EXCEEDED = 3;

--- a/packages/agency-lang/lib/constants.ts
+++ b/packages/agency-lang/lib/constants.ts
@@ -94,10 +94,10 @@ export const AGENCY_RUN_POLICY_INTERACTIVE_ON = "1";
 export const AGENCY_MAX_COST = "AGENCY_MAX_COST";
 export const AGENCY_MAX_TIME = "AGENCY_MAX_TIME";
 
-/** Absolute checkpoint path and serialized override buckets carried from
- * `agency resume` to the generated child entry. */
+/** Resume request carried from `agency resume` to the generated child entry. */
 export const AGENCY_RESUME_FILE = "AGENCY_RESUME_FILE";
 export const AGENCY_RESUME_OVERRIDES = "AGENCY_RESUME_OVERRIDES";
+export const AGENCY_RESUME_FORCE = "AGENCY_RESUME_FORCE";
 
 /** Process exit code when a top-level cost/time budget is exceeded. Distinct
  *  from 1 (generic failure) and 2 (usage error). */

--- a/packages/agency-lang/lib/runtime/checkpointTestHelpers.ts
+++ b/packages/agency-lang/lib/runtime/checkpointTestHelpers.ts
@@ -1,0 +1,25 @@
+import { Checkpoint } from "./state/checkpointStore.js";
+import { GlobalStore } from "./state/globalStore.js";
+import { StateStack } from "./state/stateStack.js";
+
+export function makeCheckpoint(
+  locals: Record<string, unknown> = {},
+  args: Record<string, unknown> = {},
+): Checkpoint {
+  const stack = new StateStack();
+  stack.nodesTraversed = ["main"];
+  const frame = stack.getNewState();
+  frame.locals = locals;
+  frame.args = args;
+  frame.scopeName = "main";
+  frame.moduleId = "";
+
+  return new Checkpoint({
+    stack: stack.toJSON(),
+    globals: new GlobalStore().toJSON(),
+    nodeId: "main",
+    moduleId: "",
+    scopeName: "main",
+    stepPath: "0",
+  });
+}

--- a/packages/agency-lang/lib/runtime/cliEntry.test.ts
+++ b/packages/agency-lang/lib/runtime/cliEntry.test.ts
@@ -10,6 +10,7 @@ import { makeCheckpoint } from "./checkpointTestHelpers.js";
 const originalResumeFile = process.env[AGENCY_RESUME_FILE];
 const originalOverrides = process.env[AGENCY_RESUME_OVERRIDES];
 const originalKey = process.env.AGENCY_CHECKPOINT_KEY;
+const originalForce = process.env.AGENCY_RESUME_FORCE;
 const dirs: string[] = [];
 
 afterEach(() => {
@@ -19,6 +20,8 @@ afterEach(() => {
   else process.env[AGENCY_RESUME_OVERRIDES] = originalOverrides;
   if (originalKey === undefined) delete process.env.AGENCY_CHECKPOINT_KEY;
   else process.env.AGENCY_CHECKPOINT_KEY = originalKey;
+  if (originalForce === undefined) delete process.env.AGENCY_RESUME_FORCE;
+  else process.env.AGENCY_RESUME_FORCE = originalForce;
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -69,11 +72,23 @@ describe("runCliEntry", () => {
     await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow("checksum");
   });
 
-  it("refuses an unsigned checkpoint when a key is configured", async () => {
+  it("allows a tampered signed checkpoint with the force carrier", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
+    process.env.AGENCY_RESUME_FORCE = "1";
+    const checkpoint = makeCheckpoint({ value: 1 });
+    signCheckpoint(checkpoint);
+    const json = checkpoint.toJSON();
+    json.nodeId = "tampered";
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(json);
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn(async () => 1) })).resolves.toBe(1);
+  });
+
+  it("accepts an unsigned checkpoint when a key is configured", async () => {
     process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
     process.env[AGENCY_RESUME_FILE] = writeCheckpoint(makeCheckpoint().toJSON());
 
-    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow("checksum");
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn(async () => 1) })).resolves.toBe(1);
   });
 
   it("treats an empty signing key as signing disabled", async () => {
@@ -85,6 +100,15 @@ describe("runCliEntry", () => {
 
   it("rejects malformed checkpoint JSON", async () => {
     process.env[AGENCY_RESUME_FILE] = writeCheckpoint({ nodeId: "main" });
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow(
+      "valid Agency checkpoint",
+    );
+  });
+
+  it("rejects malformed checkpoint JSON before checking its signature", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(null);
 
     await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow(
       "valid Agency checkpoint",

--- a/packages/agency-lang/lib/runtime/cliEntry.test.ts
+++ b/packages/agency-lang/lib/runtime/cliEntry.test.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AGENCY_RESUME_FILE, AGENCY_RESUME_OVERRIDES } from "../constants.js";
+import { runCliEntry } from "./cliEntry.js";
+import { signCheckpoint } from "./checkpointChecksum.js";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
+
+const originalResumeFile = process.env[AGENCY_RESUME_FILE];
+const originalOverrides = process.env[AGENCY_RESUME_OVERRIDES];
+const originalKey = process.env.AGENCY_CHECKPOINT_KEY;
+const dirs: string[] = [];
+
+afterEach(() => {
+  if (originalResumeFile === undefined) delete process.env[AGENCY_RESUME_FILE];
+  else process.env[AGENCY_RESUME_FILE] = originalResumeFile;
+  if (originalOverrides === undefined) delete process.env[AGENCY_RESUME_OVERRIDES];
+  else process.env[AGENCY_RESUME_OVERRIDES] = originalOverrides;
+  if (originalKey === undefined) delete process.env.AGENCY_CHECKPOINT_KEY;
+  else process.env.AGENCY_CHECKPOINT_KEY = originalKey;
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeCheckpoint(value: unknown): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "agency-cli-entry-"));
+  dirs.push(dir);
+  const filename = path.join(dir, "checkpoint.json");
+  writeFileSync(filename, JSON.stringify(value));
+  return filename;
+}
+
+describe("runCliEntry", () => {
+  it("runs main when no resume carrier exists", async () => {
+    delete process.env[AGENCY_RESUME_FILE];
+    const runMain = vi.fn(async () => "fresh");
+    const resume = vi.fn();
+
+    await expect(runCliEntry({ runMain, resume })).resolves.toBe("fresh");
+    expect(resume).not.toHaveBeenCalled();
+  });
+
+  it("resumes an unsigned checkpoint when no signing key is configured", async () => {
+    delete process.env.AGENCY_CHECKPOINT_KEY;
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(makeCheckpoint().toJSON());
+    const resume = vi.fn(async () => "resumed");
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume })).resolves.toBe("resumed");
+    expect(resume).toHaveBeenCalledWith(expect.objectContaining({ nodeId: "main" }), {});
+  });
+
+  it("accepts a checkpoint with a valid signature", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
+    const checkpoint = makeCheckpoint();
+    signCheckpoint(checkpoint);
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(checkpoint.toJSON());
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn(async () => 1) })).resolves.toBe(1);
+  });
+
+  it("refuses a tampered signed checkpoint", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
+    const checkpoint = makeCheckpoint({ value: 1 });
+    signCheckpoint(checkpoint);
+    const json = checkpoint.toJSON();
+    json.nodeId = "tampered";
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(json);
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow("checksum");
+  });
+
+  it("refuses an unsigned checkpoint when a key is configured", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "a".repeat(32);
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(makeCheckpoint().toJSON());
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow("checksum");
+  });
+
+  it("treats an empty signing key as signing disabled", async () => {
+    process.env.AGENCY_CHECKPOINT_KEY = "";
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(makeCheckpoint().toJSON());
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn(async () => 1) })).resolves.toBe(1);
+  });
+
+  it("rejects malformed checkpoint JSON", async () => {
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint({ nodeId: "main" });
+
+    await expect(runCliEntry({ runMain: vi.fn(), resume: vi.fn() })).rejects.toThrow(
+      "valid Agency checkpoint",
+    );
+  });
+
+  it("passes parsed override buckets to resume", async () => {
+    process.env[AGENCY_RESUME_FILE] = writeCheckpoint(makeCheckpoint().toJSON());
+    process.env[AGENCY_RESUME_OVERRIDES] = JSON.stringify({
+      locals: { mood: "happy" },
+      args: { name: "Ada" },
+      globals: { count: 2 },
+    });
+    const resume = vi.fn(async () => 1);
+
+    await runCliEntry({ runMain: vi.fn(), resume });
+
+    expect(resume).toHaveBeenCalledWith(expect.anything(), {
+      locals: { mood: "happy" },
+      args: { name: "Ada" },
+      globals: { count: 2 },
+    });
+  });
+});

--- a/packages/agency-lang/lib/runtime/cliEntry.ts
+++ b/packages/agency-lang/lib/runtime/cliEntry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { AGENCY_RESUME_FILE, AGENCY_RESUME_OVERRIDES } from "../constants.js";
+import { AGENCY_RESUME_FILE, AGENCY_RESUME_FORCE, AGENCY_RESUME_OVERRIDES } from "../constants.js";
 import { verifyCheckpointChecksum } from "./checkpointChecksum.js";
 import type { ResumeOverrides } from "./resumeSetup.js";
 import { Checkpoint } from "./state/checkpointStore.js";
@@ -50,14 +50,16 @@ export async function runCliEntry<T>(args: CliEntryArgs<T>): Promise<T> {
     throw new Error(`Could not read checkpoint file "${filename}": ${String(error)}`);
   }
 
-  const key = process.env.AGENCY_CHECKPOINT_KEY;
-  if (key !== undefined && key !== "" && !verifyCheckpointChecksum(raw as any)) {
-    throw new Error(`Checkpoint file "${filename}" failed checksum verification`);
-  }
-
   const checkpoint = Checkpoint.fromJSON(raw);
   if (!checkpoint) {
     throw new Error(`Checkpoint file "${filename}" does not contain a valid Agency checkpoint`);
+  }
+  if (
+    checkpoint.signature !== undefined &&
+    process.env[AGENCY_RESUME_FORCE] !== "1" &&
+    !verifyCheckpointChecksum(checkpoint)
+  ) {
+    throw new Error(`Checkpoint file "${filename}" failed checksum verification`);
   }
   return args.resume(checkpoint, parseOverrides(process.env[AGENCY_RESUME_OVERRIDES]));
 }

--- a/packages/agency-lang/lib/runtime/cliEntry.ts
+++ b/packages/agency-lang/lib/runtime/cliEntry.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { AGENCY_RESUME_FILE, AGENCY_RESUME_OVERRIDES } from "../constants.js";
+import { verifyCheckpointChecksum } from "./checkpointChecksum.js";
+import type { ResumeOverrides } from "./resumeSetup.js";
+import { Checkpoint } from "./state/checkpointStore.js";
+
+type CliEntryArgs<T> = {
+  runMain: () => Promise<T>;
+  resume: (checkpoint: Checkpoint, overrides: ResumeOverrides) => Promise<T>;
+};
+
+function parseOverrides(raw: string | undefined): ResumeOverrides {
+  if (!raw) {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${AGENCY_RESUME_OVERRIDES} is not valid JSON: ${String(error)}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${AGENCY_RESUME_OVERRIDES} must be a JSON object`);
+  }
+  for (const bucket of ["locals", "args", "globals"] as const) {
+    const value = (parsed as Record<string, unknown>)[bucket];
+    if (
+      value !== undefined &&
+      (typeof value !== "object" || value === null || Array.isArray(value))
+    ) {
+      throw new Error(`${AGENCY_RESUME_OVERRIDES}.${bucket} must be a JSON object`);
+    }
+    if (value && Object.prototype.hasOwnProperty.call(value, "__proto__")) {
+      throw new Error(`${AGENCY_RESUME_OVERRIDES}.${bucket} contains an invalid variable name`);
+    }
+  }
+  return parsed as ResumeOverrides;
+}
+
+export async function runCliEntry<T>(args: CliEntryArgs<T>): Promise<T> {
+  const filename = process.env[AGENCY_RESUME_FILE];
+  if (!filename) {
+    return args.runMain();
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(filename, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read checkpoint file "${filename}": ${String(error)}`);
+  }
+
+  const key = process.env.AGENCY_CHECKPOINT_KEY;
+  if (key !== undefined && key !== "" && !verifyCheckpointChecksum(raw as any)) {
+    throw new Error(`Checkpoint file "${filename}" failed checksum verification`);
+  }
+
+  const checkpoint = Checkpoint.fromJSON(raw);
+  if (!checkpoint) {
+    throw new Error(`Checkpoint file "${filename}" does not contain a valid Agency checkpoint`);
+  }
+  return args.resume(checkpoint, parseOverrides(process.env[AGENCY_RESUME_OVERRIDES]));
+}

--- a/packages/agency-lang/lib/runtime/debugger.test.ts
+++ b/packages/agency-lang/lib/runtime/debugger.test.ts
@@ -19,6 +19,21 @@ describe("debugStep()", () => {
     expect(result).toBeUndefined();
   });
 
+  it("skips only the first trace checkpoint after rewind", async () => {
+    const ctx = makeMockCtx();
+    let writes = 0;
+    ctx._skipNextCheckpoint = true;
+    ctx.writeCheckpointToTraceWriter = async () => {
+      writes++;
+    };
+
+    await debugStep(ctx, baseInfo);
+    await debugStep(ctx, { ...baseInfo, stepPath: "2" });
+
+    expect(writes).toBe(1);
+    expect(ctx._skipNextCheckpoint).toBe(false);
+  });
+
   it("returns interrupt when stepping with stepNext at current depth", async () => {
     const dbg = new DebuggerState(10);
     dbg.stepNext(); // stepping mode, targetDepth === callDepth (both 0)

--- a/packages/agency-lang/lib/runtime/debugger.ts
+++ b/packages/agency-lang/lib/runtime/debugger.ts
@@ -18,8 +18,11 @@ export async function debugStep(
     return undefined;
   }
 
-  // Trace write path — independent of debugger
-  if (!ctx._skipNextCheckpoint && ctx.stateStack.currentNodeId()) {
+  // A rewind marks the checkpoint at its destination as already recorded.
+  // Consume that marker here so later steps continue writing trace checkpoints.
+  const skipCheckpoint = ctx._skipNextCheckpoint;
+  ctx._skipNextCheckpoint = false;
+  if (!skipCheckpoint && ctx.stateStack.currentNodeId()) {
     const cp = Checkpoint.fromContext(ctx, info);
     await ctx.writeCheckpointToTraceWriter(cp);
   }

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -84,9 +84,9 @@ export {
   interruptWithHandlers,
   respondToInterrupts,
   respondToInterruptsForServe,
-  resumeFromCheckpoint,
+  resumeCliFromCheckpoint,
 } from "./interrupts.js";
-export type { ResumeFromCheckpointArgs } from "./interrupts.js";
+export type { ResumeCliFromCheckpointArgs } from "./interrupts.js";
 
 export { checkPolicy, checkPolicyExplicit, validatePolicy } from "./policy.js";
 

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -84,11 +84,14 @@ export {
   interruptWithHandlers,
   respondToInterrupts,
   respondToInterruptsForServe,
+  resumeFromCheckpoint,
 } from "./interrupts.js";
+export type { ResumeFromCheckpointArgs } from "./interrupts.js";
 
 export { checkPolicy, checkPolicyExplicit, validatePolicy } from "./policy.js";
 
 export { resolveCliInterrupts } from "./cliInterruptResolution.js";
+export { runCliEntry } from "./cliEntry.js";
 
 export { isGenerator, handleStreamingResponse } from "./streaming.js";
 
@@ -143,6 +146,8 @@ export { reportBudgetExceededAndExit, formatBudgetExceeded } from "./budgetExit.
 export { Runner } from "./runner.js";
 
 export { rewindFrom, applyOverrides } from "./rewind.js";
+export { applyLocalOverrides, applyRestoreOverrides, restoreForResume } from "./resumeSetup.js";
+export type { ResumeOverrides, ResumeMetadata, ResumeRequest } from "./resumeSetup.js";
 
 export { debugStep } from "./debugger.js";
 export { DebuggerState } from "../debugger/debuggerState.js";

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -23,6 +23,8 @@ import { createReturnObject, deepClone } from "./utils.js";
 import { isIpcMode, sendInterruptToParent } from "./ipc.js";
 import { alwaysScopeFor } from "./alwaysScope.js";
 import { runAsHandler, executingHandlers, insideHandlerFunction } from "./executingHandlers.js";
+import { TRACE_ID_ENV } from "../config.js";
+import { getSubprocessRunInfo } from "./subprocessRunInfo.js";
 
 // The response API lives in the cycle-free `interruptResponse.ts` leaf (imported
 // at the top of this file). Re-export so `import { approve, reject,
@@ -746,18 +748,21 @@ async function runResumeLoop(
   }
 }
 
-export type ResumeFromCheckpointArgs = {
+export type ResumeCliFromCheckpointArgs = {
   ctx: RuntimeContext<GraphState>;
   checkpoint: Checkpoint;
   overrides?: ResumeOverrides;
 };
 
-/** Resume a checkpoint as a complete CLI invocation, without fabricating an
- * interrupt response. Unlike debugger rewind, this path owns the run lifecycle
- * and therefore closes a completed trace or pauses one that interrupts again. */
-export async function resumeFromCheckpoint(args: ResumeFromCheckpointArgs): Promise<any> {
-  const runId = (args.ctx as any).runId ?? nanoid();
-  const execCtx = await args.ctx.createExecutionContext({ runId });
+/** Resume a checkpoint as a complete CLI run, including lifecycle events and
+ * trace finalization. */
+export async function resumeCliFromCheckpoint(args: ResumeCliFromCheckpointArgs): Promise<any> {
+  const resolved = resolveInvocation({
+    kind: "fresh",
+    inheritedRunId: getSubprocessRunInfo().runId,
+    environmentTraceId: process.env[TRACE_ID_ENV],
+  });
+  const execCtx = await args.ctx.createExecutionContext(resolved);
   const agentStartTime = performance.now();
   let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
   try {
@@ -765,7 +770,6 @@ export async function resumeFromCheckpoint(args: ResumeFromCheckpointArgs): Prom
       checkpoint: args.checkpoint,
       overrides: args.overrides,
     });
-    execCtx._skipNextCheckpoint = true;
     agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
     execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
     return await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -6,19 +6,13 @@ import { approve, reject } from "./interruptResponse.js";
 import type { InterruptApprove, InterruptReject, InterruptResponse } from "./interruptResponse.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
 import { resolveInvocation, type InvocationOptions } from "./invocationOptions.js";
-import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
-import { reinstallRootBudget } from "./rootBudget.js";
-import { assertCodeUnchanged } from "./referencedModules.js";
 import { AgencyCancelledError, HandlerRecursionError, RestoreSignal } from "./errors.js";
 import { isAborted } from "./abortedResult.js";
 import { throwIfNodeResultAborted } from "./abortBoundary.js";
 import { mergeFor, mergeForIpc } from "./effectMerge.js";
-import { applyOverrides } from "./rewind.js";
+import { applyRestoreOverrides, restoreForResume, type ResumeOverrides } from "./resumeSetup.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import { RuntimeContext } from "./state/context.js";
-import { loadProviderModules } from "./providerModules.js";
-import { ensureConfiguredLocalProvider } from "./localProvider.js";
-import { installRunPolicyHandler } from "./runPolicyHandler.js";
 import { GlobalStore, GlobalStoreJSON } from "./state/globalStore.js";
 import { StateStack, StateStackJSON } from "./state/stateStack.js";
 import { Approved, GraphState, Rejected, RunNodeResult } from "./types.js";
@@ -742,11 +736,56 @@ async function runResumeLoop(
           restoreCount: execCtx._restoreCount,
         });
         execCtx.restoreState(cp);
+        applyRestoreOverrides(execCtx, cp, e.options);
         nodeName = cp.nodeId;
         execCtx.stateStack.nodesTraversed = [cp.nodeId];
         continue;
       }
       throw e;
+    }
+  }
+}
+
+export type ResumeFromCheckpointArgs = {
+  ctx: RuntimeContext<GraphState>;
+  checkpoint: Checkpoint;
+  overrides?: ResumeOverrides;
+};
+
+/** Resume a checkpoint as a complete CLI invocation, without fabricating an
+ * interrupt response. Unlike debugger rewind, this path owns the run lifecycle
+ * and therefore closes a completed trace or pauses one that interrupts again. */
+export async function resumeFromCheckpoint(args: ResumeFromCheckpointArgs): Promise<any> {
+  const runId = (args.ctx as any).runId ?? nanoid();
+  const execCtx = await args.ctx.createExecutionContext({ runId });
+  const agentStartTime = performance.now();
+  let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
+  try {
+    const checkpoint = await restoreForResume(execCtx, {
+      checkpoint: args.checkpoint,
+      overrides: args.overrides,
+    });
+    execCtx._skipNextCheckpoint = true;
+    agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
+    execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
+    return await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    execCtx.statelogClient.error({ errorType: "runtimeError", message: errorMessage });
+    execCtx.statelogClient.agentEnd({
+      entryNode: args.checkpoint.nodeId,
+      timeTaken: performance.now() - agentStartTime,
+    });
+    await execCtx.closeTraceWriter();
+    throw error;
+  } finally {
+    if (agentRunSpanId !== undefined) {
+      execCtx.statelogClient.endSpan(agentRunSpanId);
+    }
+    try {
+      await execCtx.statelogClient.flush();
+    } finally {
+      execCtx.cleanup();
     }
   }
 }
@@ -781,10 +820,6 @@ async function respondToInterruptsCore(
       "No checkpoint found for interrupt. The interrupt may have been created with an older format.",
     );
   }
-  if (args.overrides) applyOverrides(checkpoint, args.overrides);
-  // A changed module would be replayed against different statement numbering;
-  // refuse before any state is restored.
-  assertCodeUnchanged(checkpoint.moduleFingerprints);
 
   // Resume always keeps interrupt.runId; the resolver ignores any supplied
   // traceId and applies only the per-invocation config projection.
@@ -802,64 +837,27 @@ async function respondToInterruptsCore(
   let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
   let outcome: RawOutcome<RunNodeResult<any>>;
   try {
-    // Re-install the root policy handler on the resumed exec context
-    // (handlers are never checkpointed): the invocation's policy when one
-    // was resolved, else the AGENCY_RUN_POLICY environment policy. Mirrors
-    // the runNode install, so a raise made DURING this resume leg is decided
-    // by the same root policy as on a fresh run.
-    installRunPolicyHandler(execCtx, resolved.policy);
-    // A cross-process resume starts with an empty provider registry (registration
-    // is process-global, not part of serialized checkpoint state), so re-register
-    // before resuming. Idempotent in-process via loadProviderModules' guard.
-    await loadProviderModules(execCtx);
-    await ensureConfiguredLocalProvider(execCtx);
-    // This is the first restore on this execCtx — record it as such.
-    execCtx._restoreCount++;
-    execCtx.statelogClient.checkpointRestored({
-      checkpointId: checkpoint.id,
-      restoreCount: execCtx._restoreCount,
+    await restoreForResume(execCtx, {
+      checkpoint,
+      policy: resolved.policy,
+      overrides: { locals: args.overrides },
+      metadata,
+      afterCheckpointRestored: () => {
+        if (!isIpcMode()) {
+          for (let i = 0; i < interrupts.length; i++) {
+            const intr = interrupts[i];
+            const resp = responses[i];
+            const resolvedOutcome = resp.type === "approve" ? "approved" : ("rejected" as const);
+            execCtx.statelogClient.interruptResolved({
+              interruptId: intr.interruptId,
+              outcome: resolvedOutcome,
+              resolvedBy: "user",
+            });
+          }
+        }
+      },
     });
-    // Each user response resolves a previously-thrown interrupt. Emit the
-    // lifecycle event so dashboards can pair every interruptThrown with a
-    // terminal interruptResolved. Suppressed in IPC mode: a resumed
-    // subprocess segment re-enters respondToInterrupts with the SAME
-    // preserved interrupt ids in the same inherited trace, and the root
-    // process already emitted the user resolution — a second (or, nested,
-    // N+1th) emission would break thrown↔resolved pairing for consumers.
-    if (!isIpcMode()) {
-      for (let i = 0; i < interrupts.length; i++) {
-        const intr = interrupts[i];
-        const resp = responses[i];
-        const resolvedOutcome = resp.type === "approve" ? "approved" : ("rejected" as const);
-        execCtx.statelogClient.interruptResolved({
-          interruptId: intr.interruptId,
-          outcome: resolvedOutcome,
-          resolvedBy: "user",
-        });
-      }
-    }
-    // Re-register top-level callbacks BEFORE restoreState so the
-    // `_callbackImpl` routing check (`stateStack.isGlobalContext()`)
-    // sees the still-empty stack and pushes onto `ctx.topLevelCallbacks`.
-    // After `restoreState`, the stack carries the checkpoint frames and
-    // the same registration would instead bind to a caller frame and be
-    // popped immediately as the restored frames unwind.
-    //
-    // The bootstrap frame mirrors `runNode` — top-level callback
-    // registration runs Agency code that goes through `__call`, which
-    // reads ctx/threads/stack from ALS after the
-    // drop-per-call-context-plumbing migration. See lib/runtime/node.ts
-    // and lib/runtime/asyncContext.ts (`runInBootstrapFrame`).
-    await runInBootstrapFrame(execCtx, () => __initAllRegisteredCallbacks(execCtx));
-    execCtx.restoreState(checkpoint);
-    // Re-assert the root budget's LIMIT from the host context (the checkpoint's
-    // ceiling is caller-controllable on a stateless resume), while preserving the
-    // guard's accumulated spend so the trusted CLI resume path stays cumulative.
-    // No-op in IPC.
-    reinstallRootBudget(execCtx.stateStack, execCtx.budget);
     execCtx.setInterruptResponses(responseMap);
-    if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
-    if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
 
     agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
     execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -7,6 +7,7 @@ import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, CheckpointError, RestoreSignal } from "./errors.js";
+import { applyRestoreOverrides } from "./resumeSetup.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { __initAllRegistered, __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
@@ -534,15 +535,7 @@ async function runNodeCore({
             },
           });
           execCtx.restoreState(cp);
-          if (e.options?.args) {
-            execCtx._pendingArgOverrides = e.options.args;
-          }
-          if (e.options?.globals) {
-            // eslint-disable-next-line max-depth -- applying restored globals overrides
-            for (const [varName, value] of Object.entries(e.options.globals)) {
-              execCtx.globals.set(cp.moduleId, varName, value);
-            }
-          }
+          applyRestoreOverrides(execCtx, cp, e.options);
           nodeName = cp.nodeId;
           data = {};
           isResume = true;

--- a/packages/agency-lang/lib/runtime/resumeSetup.test.ts
+++ b/packages/agency-lang/lib/runtime/resumeSetup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
+import { applyLocalOverrides, applyRestoreOverrides } from "./resumeSetup.js";
+import { GlobalStore } from "./state/globalStore.js";
+import { StateStack } from "./state/stateStack.js";
+
+describe("resume setup", () => {
+  it("applies local overrides without mutating the source checkpoint", () => {
+    const source = makeCheckpoint({ mood: "sad", count: 1 });
+
+    const changed = applyLocalOverrides(source, { mood: "happy" });
+
+    expect(StateStack.lastFrameJSON(changed.stack).locals).toEqual({ mood: "happy", count: 1 });
+    expect(StateStack.lastFrameJSON(source.stack).locals).toEqual({ mood: "sad", count: 1 });
+  });
+
+  it("applies argument and checkpoint-module global overrides", () => {
+    const checkpoint = makeCheckpoint({}, { name: "before" });
+    checkpoint.moduleId = "fixture.agency";
+    const stateStack = StateStack.fromJSON(checkpoint.stack);
+    const globals = GlobalStore.fromJSON(checkpoint.globals);
+    const target = {
+      stateStack,
+      globals,
+      _pendingArgOverrides: undefined as Record<string, unknown> | undefined,
+    };
+
+    applyRestoreOverrides(target, checkpoint, {
+      args: { name: "after" },
+      globals: { enabled: true },
+    });
+
+    expect(target._pendingArgOverrides).toEqual({ name: "after" });
+    expect(globals.get("fixture.agency", "enabled")).toBe(true);
+  });
+
+  it("does nothing when no overrides are supplied", () => {
+    const checkpoint = makeCheckpoint();
+    const stateStack = StateStack.fromJSON(checkpoint.stack);
+    const globals = GlobalStore.fromJSON(checkpoint.globals);
+    const target = { stateStack, globals, _pendingArgOverrides: undefined };
+
+    applyRestoreOverrides(target, checkpoint);
+
+    expect(target._pendingArgOverrides).toBeUndefined();
+    expect(globals.toJSON()).toEqual(checkpoint.globals);
+  });
+});

--- a/packages/agency-lang/lib/runtime/resumeSetup.test.ts
+++ b/packages/agency-lang/lib/runtime/resumeSetup.test.ts
@@ -14,15 +14,25 @@ describe("resume setup", () => {
     expect(StateStack.lastFrameJSON(source.stack).locals).toEqual({ mood: "sad", count: 1 });
   });
 
+  it("rejects prototype-mutating local overrides from programmatic callers", () => {
+    const source = makeCheckpoint({ mood: "sad" });
+    const overrides = JSON.parse('{"__proto__":{"polluted":true}}');
+
+    expect(() => applyLocalOverrides(source, overrides)).toThrow("invalid override name");
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
   it("applies argument and checkpoint-module global overrides", () => {
     const checkpoint = makeCheckpoint({}, { name: "before" });
     checkpoint.moduleId = "fixture.agency";
+    checkpoint.nodeId = "main";
+    StateStack.lastFrameJSON(checkpoint.stack).scopeName = "greet";
     const stateStack = StateStack.fromJSON(checkpoint.stack);
     const globals = GlobalStore.fromJSON(checkpoint.globals);
     const target = {
       stateStack,
       globals,
-      _pendingArgOverrides: undefined as Record<string, unknown> | undefined,
+      _pendingArgOverrides: undefined,
     };
 
     applyRestoreOverrides(target, checkpoint, {
@@ -30,8 +40,76 @@ describe("resume setup", () => {
       globals: { enabled: true },
     });
 
-    expect(target._pendingArgOverrides).toEqual({ name: "after" });
+    expect(target._pendingArgOverrides).toEqual({
+      moduleId: "",
+      scopeName: "greet",
+      values: { name: "after" },
+    });
     expect(globals.get("fixture.agency", "enabled")).toBe(true);
+  });
+
+  it("queues argument overrides only for a paused function frame", () => {
+    const nodeCheckpoint = makeCheckpoint({}, { name: "before" });
+    nodeCheckpoint.nodeId = "main";
+    StateStack.lastFrameJSON(nodeCheckpoint.stack).scopeName = "main";
+    const nodeTarget = {
+      stateStack: StateStack.fromJSON(nodeCheckpoint.stack),
+      globals: GlobalStore.fromJSON(nodeCheckpoint.globals),
+      _pendingArgOverrides: undefined,
+    };
+
+    applyRestoreOverrides(nodeTarget, nodeCheckpoint, { args: { name: "after" } });
+
+    expect(nodeTarget._pendingArgOverrides).toBeUndefined();
+
+    const functionCheckpoint = makeCheckpoint({}, { name: "before" });
+    functionCheckpoint.nodeId = "main";
+    StateStack.lastFrameJSON(functionCheckpoint.stack).scopeName = "greet";
+    const functionTarget = {
+      stateStack: StateStack.fromJSON(functionCheckpoint.stack),
+      globals: GlobalStore.fromJSON(functionCheckpoint.globals),
+      _pendingArgOverrides: undefined,
+    };
+
+    applyRestoreOverrides(functionTarget, functionCheckpoint, { args: { name: "after" } });
+
+    expect(functionTarget._pendingArgOverrides).toEqual({
+      moduleId: "",
+      scopeName: "greet",
+      values: { name: "after" },
+    });
+  });
+
+  it("rejects prototype-mutating argument and global overrides", () => {
+    const checkpoint = makeCheckpoint();
+    checkpoint.moduleId = "fixture.agency";
+    const target = {
+      stateStack: StateStack.fromJSON(checkpoint.stack),
+      globals: GlobalStore.fromJSON(checkpoint.globals),
+      _pendingArgOverrides: undefined,
+    };
+    const polluted = JSON.parse('{"__proto__":{"polluted":true}}');
+
+    expect(() => applyRestoreOverrides(target, checkpoint, { args: polluted })).toThrow(
+      "invalid override name",
+    );
+    expect(() => applyRestoreOverrides(target, checkpoint, { globals: polluted })).toThrow(
+      "invalid override name",
+    );
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it("rejects a prototype property as the global module id", () => {
+    const checkpoint = makeCheckpoint();
+    checkpoint.moduleId = "__proto__";
+    const target = {
+      stateStack: StateStack.fromJSON(checkpoint.stack),
+      globals: GlobalStore.fromJSON(checkpoint.globals),
+    };
+
+    expect(() => applyRestoreOverrides(target, checkpoint, { globals: { enabled: true } })).toThrow(
+      "invalid module id",
+    );
   });
 
   it("does nothing when no overrides are supplied", () => {

--- a/packages/agency-lang/lib/runtime/resumeSetup.ts
+++ b/packages/agency-lang/lib/runtime/resumeSetup.ts
@@ -1,0 +1,111 @@
+import type { DebuggerState } from "../debugger/debuggerState.js";
+import { runInBootstrapFrame } from "./asyncContext.js";
+import { signCheckpoint } from "./checkpointChecksum.js";
+import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
+import type { AgencyCallbacks } from "./hooks.js";
+import { ensureConfiguredLocalProvider } from "./localProvider.js";
+import type { Policy } from "./policy.js";
+import { loadProviderModules } from "./providerModules.js";
+import { assertCodeUnchanged } from "./referencedModules.js";
+import { reinstallRootBudget } from "./rootBudget.js";
+import { installRunPolicyHandler } from "./runPolicyHandler.js";
+import type { Checkpoint } from "./state/checkpointStore.js";
+import type { RuntimeContext } from "./state/context.js";
+import type { GlobalStore } from "./state/globalStore.js";
+import { StateStack } from "./state/stateStack.js";
+import type { GraphState } from "./types.js";
+import { deepClone } from "./utils.js";
+
+export type ResumeOverrides = {
+  locals?: Record<string, unknown>;
+  args?: Record<string, unknown>;
+  globals?: Record<string, unknown>;
+};
+
+export type ResumeMetadata = {
+  callbacks?: AgencyCallbacks;
+  debugger?: DebuggerState;
+};
+
+export type AfterCheckpointRestored = () => void;
+
+export type ResumeRequest = {
+  checkpoint: Checkpoint;
+  policy?: Policy;
+  overrides?: ResumeOverrides;
+  metadata?: ResumeMetadata;
+  afterCheckpointRestored?: AfterCheckpointRestored;
+};
+
+type RestoreOverrideTarget = {
+  stateStack: StateStack;
+  globals: GlobalStore;
+  _pendingArgOverrides?: Record<string, unknown>;
+};
+
+export function applyLocalOverrides(
+  source: Checkpoint,
+  overrides: Record<string, unknown> = {},
+): Checkpoint {
+  const checkpoint = deepClone(source);
+  const frame = StateStack.lastFrameJSON(checkpoint.stack);
+  for (const [key, value] of Object.entries(overrides)) {
+    frame.locals[key] = value;
+  }
+  if (checkpoint.signature !== undefined) {
+    signCheckpoint(checkpoint);
+  }
+  return checkpoint;
+}
+
+export function applyRestoreOverrides(
+  target: RestoreOverrideTarget,
+  checkpoint: Checkpoint,
+  overrides: Pick<ResumeOverrides, "args" | "globals"> = {},
+): void {
+  if (overrides.args) {
+    target._pendingArgOverrides = overrides.args;
+  }
+  if (overrides.globals) {
+    for (const [name, value] of Object.entries(overrides.globals)) {
+      target.globals.set(checkpoint.moduleId, name, value);
+    }
+  }
+}
+
+export async function restoreForResume(
+  execCtx: RuntimeContext<GraphState>,
+  request: ResumeRequest,
+): Promise<Checkpoint> {
+  const checkpoint = applyLocalOverrides(request.checkpoint, request.overrides?.locals);
+  if (request.overrides?.args) {
+    Object.assign(StateStack.lastFrameJSON(checkpoint.stack).args, request.overrides.args);
+    if (checkpoint.signature !== undefined) {
+      signCheckpoint(checkpoint);
+    }
+  }
+  assertCodeUnchanged(checkpoint.moduleFingerprints);
+  installRunPolicyHandler(execCtx, request.policy);
+  await loadProviderModules(execCtx);
+  await ensureConfiguredLocalProvider(execCtx);
+
+  execCtx._restoreCount++;
+  execCtx.statelogClient.checkpointRestored({
+    checkpointId: checkpoint.id,
+    restoreCount: execCtx._restoreCount,
+  });
+  request.afterCheckpointRestored?.();
+
+  await runInBootstrapFrame(execCtx, () => __initAllRegisteredCallbacks(execCtx));
+  execCtx.restoreState(checkpoint);
+  reinstallRootBudget(execCtx.stateStack, execCtx.budget);
+  applyRestoreOverrides(execCtx, checkpoint, { globals: request.overrides?.globals });
+
+  if (request.metadata?.callbacks) {
+    Object.assign(execCtx.callbacks, request.metadata.callbacks);
+  }
+  if (request.metadata?.debugger) {
+    execCtx.debuggerState = request.metadata.debugger;
+  }
+  return checkpoint;
+}

--- a/packages/agency-lang/lib/runtime/resumeSetup.ts
+++ b/packages/agency-lang/lib/runtime/resumeSetup.ts
@@ -10,7 +10,7 @@ import { assertCodeUnchanged } from "./referencedModules.js";
 import { reinstallRootBudget } from "./rootBudget.js";
 import { installRunPolicyHandler } from "./runPolicyHandler.js";
 import type { Checkpoint } from "./state/checkpointStore.js";
-import type { RuntimeContext } from "./state/context.js";
+import type { PendingArgOverrides, RuntimeContext } from "./state/context.js";
 import type { GlobalStore } from "./state/globalStore.js";
 import { StateStack } from "./state/stateStack.js";
 import type { GraphState } from "./types.js";
@@ -40,8 +40,19 @@ export type ResumeRequest = {
 type RestoreOverrideTarget = {
   stateStack: StateStack;
   globals: GlobalStore;
-  _pendingArgOverrides?: Record<string, unknown>;
+  _pendingArgOverrides?: PendingArgOverrides;
 };
+
+function checkedOverrides(overrides: Record<string, unknown>): Record<string, unknown> {
+  const checked = Object.create(null) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (key === "__proto__") {
+      throw new Error(`Resume request contains invalid override name "${key}"`);
+    }
+    checked[key] = value;
+  }
+  return checked;
+}
 
 export function applyLocalOverrides(
   source: Checkpoint,
@@ -49,7 +60,7 @@ export function applyLocalOverrides(
 ): Checkpoint {
   const checkpoint = deepClone(source);
   const frame = StateStack.lastFrameJSON(checkpoint.stack);
-  for (const [key, value] of Object.entries(overrides)) {
+  for (const [key, value] of Object.entries(checkedOverrides(overrides))) {
     frame.locals[key] = value;
   }
   if (checkpoint.signature !== undefined) {
@@ -64,10 +75,21 @@ export function applyRestoreOverrides(
   overrides: Pick<ResumeOverrides, "args" | "globals"> = {},
 ): void {
   if (overrides.args) {
-    target._pendingArgOverrides = overrides.args;
+    const args = checkedOverrides(overrides.args);
+    const frame = StateStack.lastFrameJSON(checkpoint.stack);
+    if (frame.scopeName !== checkpoint.nodeId) {
+      target._pendingArgOverrides = {
+        moduleId: frame.moduleId ?? null,
+        scopeName: frame.scopeName,
+        values: args,
+      };
+    }
   }
   if (overrides.globals) {
-    for (const [name, value] of Object.entries(overrides.globals)) {
+    if (Object.prototype.hasOwnProperty.call(Object.prototype, checkpoint.moduleId)) {
+      throw new Error(`Resume checkpoint contains invalid module id "${checkpoint.moduleId}"`);
+    }
+    for (const [name, value] of Object.entries(checkedOverrides(overrides.globals))) {
       target.globals.set(checkpoint.moduleId, name, value);
     }
   }
@@ -79,7 +101,9 @@ export async function restoreForResume(
 ): Promise<Checkpoint> {
   const checkpoint = applyLocalOverrides(request.checkpoint, request.overrides?.locals);
   if (request.overrides?.args) {
-    Object.assign(StateStack.lastFrameJSON(checkpoint.stack).args, request.overrides.args);
+    for (const [name, value] of Object.entries(checkedOverrides(request.overrides.args))) {
+      StateStack.lastFrameJSON(checkpoint.stack).args[name] = value;
+    }
     if (checkpoint.signature !== undefined) {
       signCheckpoint(checkpoint);
     }
@@ -99,7 +123,10 @@ export async function restoreForResume(
   await runInBootstrapFrame(execCtx, () => __initAllRegisteredCallbacks(execCtx));
   execCtx.restoreState(checkpoint);
   reinstallRootBudget(execCtx.stateStack, execCtx.budget);
-  applyRestoreOverrides(execCtx, checkpoint, { globals: request.overrides?.globals });
+  applyRestoreOverrides(execCtx, checkpoint, {
+    args: request.overrides?.args,
+    globals: request.overrides?.globals,
+  });
 
   if (request.metadata?.callbacks) {
     Object.assign(execCtx.callbacks, request.metadata.callbacks);

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -1,27 +1,16 @@
 import type { Checkpoint } from "./state/checkpointStore.js";
-import { signCheckpoint } from "./checkpointChecksum.js";
 import { throwIfNodeResultAborted } from "./abortBoundary.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
-import { __initAllRegisteredCallbacks } from "./crossModuleInitRegistry.js";
 import { RestoreSignal } from "./errors.js";
+import { applyLocalOverrides, applyRestoreOverrides, restoreForResume } from "./resumeSetup.js";
 import { RuntimeContext } from "./state/context.js";
-import { StateStack } from "./state/stateStack.js";
 import type { GraphState } from "./types.js";
-import { createReturnObject, deepClone } from "./utils.js";
-import { color } from "@/utils/termcolors.js";
+import { createReturnObject } from "./utils.js";
 import { nanoid } from "nanoid";
 
 export function applyOverrides(checkpoint: Checkpoint, overrides: Record<string, unknown>): void {
-  const frame = StateStack.lastFrameJSON(checkpoint.stack);
-  for (const [key, value] of Object.entries(overrides)) {
-    frame.locals[key] = value;
-  }
-  // Re-sign after the edit. Also runs on the served resume path with caller
-  // overrides — safe: a host verifies before responding, and the re-signed
-  // object is never returned to the caller.
-  if (checkpoint.signature !== undefined) {
-    signCheckpoint(checkpoint);
-  }
+  const changed = applyLocalOverrides(checkpoint, overrides);
+  Object.assign(checkpoint, changed);
 }
 
 export async function rewindFrom(args: {
@@ -31,10 +20,6 @@ export async function rewindFrom(args: {
   metadata?: Record<string, any>;
 }): Promise<any> {
   const { ctx, overrides, metadata = {} } = args;
-  const checkpoint = deepClone(args.checkpoint);
-
-  applyOverrides(checkpoint, overrides);
-
   // A rewind is conceptually a new execution: it builds a fresh execCtx
   // and replays from the checkpoint. The module-level `__globalCtx` that
   // callers pass in never has runId set (only per-run execCtx do), so we
@@ -42,28 +27,15 @@ export async function rewindFrom(args: {
   // runs in trace files, which matches the actual execution semantics.
   const runId = (ctx as any).runId ?? nanoid();
   const execCtx = await ctx.createExecutionContext({ runId });
-  // Must run before restoreState so the empty stack routes the
-  // registration to `ctx.topLevelCallbacks`. See the matching comment
-  // in `respondToInterrupts`. The bootstrap frame is also mirrored
-  // from there — top-level callback registration runs Agency code
-  // (the `callback(...)` wrapper) that needs an ALS frame for
-  // `__call` post-migration. See `runInBootstrapFrame` in
-  // lib/runtime/asyncContext.ts.
-  await runInBootstrapFrame(execCtx, () => __initAllRegisteredCallbacks(execCtx));
-  execCtx.restoreState(checkpoint);
-  execCtx._skipNextCheckpoint = true;
-
-  if (metadata.callbacks) {
-    Object.assign(execCtx.callbacks, metadata.callbacks);
-  }
-
-  if (metadata.debugger) {
-    execCtx.debuggerState = metadata.debugger;
-  }
-
-  let nodeName = checkpoint.nodeId;
-
   try {
+    const checkpoint = await restoreForResume(execCtx, {
+      checkpoint: args.checkpoint,
+      overrides: { locals: overrides },
+      metadata,
+    });
+    execCtx._skipNextCheckpoint = true;
+    let nodeName = checkpoint.nodeId;
+
     while (true) {
       try {
         // See `runResumeLoop` in lib/runtime/interrupts.ts — stdlib
@@ -95,6 +67,7 @@ export async function rewindFrom(args: {
         if (e instanceof RestoreSignal) {
           const cp = e.checkpoint;
           execCtx.restoreState(cp);
+          applyRestoreOverrides(execCtx, cp, e.options);
           nodeName = cp.nodeId;
           execCtx.stateStack.nodesTraversed = [cp.nodeId];
           continue;

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -80,6 +80,12 @@ function defaultClock(): Clock {
   return process.env.AGENCY_FAKE_CLOCK === "1" ? new FakeClock() : realClock;
 }
 
+export type PendingArgOverrides = {
+  moduleId: string | null;
+  scopeName: string | null;
+  values: Record<string, unknown>;
+};
+
 /* bunch of stuff that every node/function in the runtime needs access to,
 that we don't want to pass as individual arguments everywhere */
 export class RuntimeContext<T> {
@@ -109,7 +115,7 @@ export class RuntimeContext<T> {
   pendingPromises: PendingPromiseStore;
   graph: SimpleMachine<T>;
   _skipNextCheckpoint: boolean;
-  _pendingArgOverrides?: Record<string, any>;
+  _pendingArgOverrides?: PendingArgOverrides;
   _restoreCount: number;
 
   /* Here is why this is needed: When you're stepping through the code,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -55,6 +57,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -57,7 +57,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -20,7 +20,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -62,7 +62,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // \`agency serve\` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -11,7 +11,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -20,6 +20,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -42,6 +43,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -60,6 +62,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // \`agency serve\` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
@@ -11,8 +11,11 @@
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 {{{paramsStr}}}
 }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
@@ -16,8 +16,11 @@ export const template = `// \`__resultCheckpointId\` is referenced by interruptA
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 {{{paramsStr}}}
 }

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -49,6 +49,8 @@ import type { RemoteCommandContext } from "@/cli/remote/commands/util.js";
 import { lintSource } from "@/linter/registry.js";
 import { formatFindings } from "@/cli/lint.js";
 import { resolveBudget } from "@/cli/budget.js";
+import { parseResumeOverrides } from "@/cli/resumeOverrides.js";
+import { resolveResumeCarrier, type ResumeCarrier } from "@/cli/resumeCarrier.js";
 import { fixtures, test, testTs, parseShardSpec, TestRunOptions } from "@/cli/test.js";
 import { caseTimings, failedFiles } from "@/cli/testReport.js";
 import { humanOutput, jsonOutput, type TestOutput } from "@/cli/testOutput.js";
@@ -128,13 +130,11 @@ import { startMcpServer } from "@/mcp/server.js";
 import { pathToFileURL } from "url";
 import { serveMcp, serveHttp } from "@/cli/serve.js";
 
-// Per-run flags for `agency run` / the hidden default command: the shared
-// CliFlags (mapped onto config by applyCliFlags in config.ts) plus --resume,
-// which is a run-only concern, not a config field.
+// Per-run flags for `agency run`, `agency resume`, and the hidden default
+// command. CliFlags are mapped onto config by applyCliFlags in config.ts.
 type RunOptions = Omit<CliFlags, "trace"> & {
   trace?: boolean;
   traceFile?: string;
-  resume?: string;
   policy?: string;
   approve?: string;
   reject?: string;
@@ -144,6 +144,13 @@ type RunOptions = Omit<CliFlags, "trace"> & {
   local?: string;
   captureWorkdir?: string;
   agencyOnly?: boolean;
+};
+
+type ResumeOptions = RunOptions & {
+  localVar?: string[];
+  globalVar?: string[];
+  arg?: string[];
+  programArg?: string[];
 };
 
 // commander option parsers. Match the WHOLE string against digits so
@@ -255,7 +262,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
     return { config: getConfig(), configPath };
   }
 
-  async function runWithOptions(input: string, options: RunOptions, nodeArgs: string[] = []) {
+  async function runWithOptions(
+    input: string,
+    options: RunOptions,
+    nodeArgs: string[] = [],
+    resume?: ResumeCarrier,
+  ) {
     if (options.local !== undefined && options.model !== undefined) {
       console.error("Error: Pass either --model (hosted) or --local (local), not both.");
       process.exit(2);
@@ -306,7 +318,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       config,
       input,
       undefined,
-      options.resume,
+      resume,
       runPolicy,
       budget,
       nodeArgs,
@@ -397,7 +409,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
   function addRunOptions(cmd: Command) {
     return (
       cmd
-        .option("--resume <statefile>", "Resume execution from a saved state file")
         // Two flags rather than `--trace [file]`: an optional-valued option
         // swallows the next word, so `agency run --trace greet.agency` reads the
         // filename as the trace path and then reports the input missing. That was
@@ -494,6 +505,47 @@ export function createProgram(deps: CliDependencies = {}): Command {
       command.unknownFallbackOperand(input);
     }
     await runWithOptions(input, options, nodeArgs);
+  });
+
+  addRunOptions(
+    program
+      .command("resume")
+      .description("Resume an Agency program from a checkpoint file")
+      .argument("<checkpoint-file>", "Path to checkpoint JSON")
+      .argument("<input>", "Path to the .agency program that created the checkpoint")
+      .option(
+        "--local-var <name=value>",
+        "Override a local variable in the checkpoint's current frame (repeatable)",
+        collectRepeats,
+        [] as string[],
+      )
+      .option(
+        "--global-var <name=value>",
+        "Override a global variable in the checkpoint's module (repeatable)",
+        collectRepeats,
+        [] as string[],
+      )
+      .option(
+        "--arg <name=value>",
+        "Override a resumed function or node argument (repeatable)",
+        collectRepeats,
+        [] as string[],
+      )
+      .option(
+        "--program-arg <value>",
+        "Pass one value to std::args in the resumed program (repeatable)",
+        collectRepeats,
+        [] as string[],
+      ),
+  ).action(async (checkpointFile: string, input: string, options: ResumeOptions) => {
+    let resume: ResumeCarrier;
+    try {
+      resume = resolveResumeCarrier(checkpointFile, parseResumeOverrides(options));
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exit(2);
+    }
+    await runWithOptions(input, options, options.programArg ?? [], resume);
   });
 
   program
@@ -785,10 +837,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .description("Compile and run .agency file, generating a trace")
     .argument("<input>", "Path to .agency input file")
     .option("-o, --output <file>", "Output trace file path (default: <input>.trace)")
-    .option("--resume <statefile>", "Resume execution from a saved state file")
-    .action(async (input: string, options: { output?: string; resume?: string }) => {
+    .action(async (input: string, options: { output?: string }) => {
       const traceFile = options.output || input.replace(/\.agency$/, ".trace");
-      await runWithOptions(input, { traceFile, resume: options.resume });
+      await runWithOptions(input, { traceFile });
     });
 
   traceCmd

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -151,6 +151,7 @@ type ResumeOptions = RunOptions & {
   globalVar?: string[];
   arg?: string[];
   programArg?: string[];
+  force?: boolean;
 };
 
 // commander option parsers. Match the WHOLE string against digits so
@@ -536,11 +537,16 @@ export function createProgram(deps: CliDependencies = {}): Command {
         "Pass one value to std::args in the resumed program (repeatable)",
         collectRepeats,
         [] as string[],
-      ),
+      )
+      .option("-f, --force", "Resume even when a checkpoint signature cannot be verified"),
   ).action(async (checkpointFile: string, input: string, options: ResumeOptions) => {
     let resume: ResumeCarrier;
     try {
-      resume = resolveResumeCarrier(checkpointFile, parseResumeOverrides(options));
+      resume = resolveResumeCarrier(
+        checkpointFile,
+        parseResumeOverrides(options),
+        options.force ?? false,
+      );
     } catch (error) {
       console.error(`Error: ${(error as Error).message}`);
       process.exit(2);

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -307,7 +310,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -321,7 +324,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -365,7 +368,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -307,7 +310,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("val" in __overrides) {
     val = __overrides["val"];

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -494,7 +497,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -319,7 +322,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -497,7 +500,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("sleepTime" in __overrides) {
     sleepTime = __overrides["sleepTime"];

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -483,7 +486,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("data" in __overrides) {
     data = __overrides["data"];

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -463,7 +466,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -306,7 +309,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("block" in __overrides) {
     block = __overrides["block"];

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -532,7 +535,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -555,7 +558,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("items" in __overrides) {
     items = __overrides["items"];

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -327,7 +330,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -363,7 +366,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -504,7 +507,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -233,8 +233,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -494,7 +497,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -235,8 +235,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];
@@ -372,8 +375,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("p" in __overrides) {
     p = __overrides["p"];
@@ -518,8 +524,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -756,7 +759,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -225,8 +225,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -432,7 +435,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -94,6 +96,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -96,7 +96,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -230,8 +230,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];
@@ -384,8 +387,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];
@@ -526,8 +532,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("width" in __overrides) {
     width = __overrides["width"];
@@ -684,8 +693,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }
@@ -811,8 +823,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -295,7 +298,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -326,7 +329,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -324,7 +327,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -308,7 +311,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("n" in __overrides) {
     n = __overrides["n"];

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -506,7 +509,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -681,7 +684,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -229,8 +229,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];
@@ -405,8 +408,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -327,7 +330,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("n" in __overrides) {
     n = __overrides["n"];

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -542,7 +545,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -622,7 +625,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -229,8 +229,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("c" in __overrides) {
     c = __overrides["c"];

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -327,7 +330,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("n" in __overrides) {
     n = __overrides["n"];

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -542,7 +545,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -389,7 +392,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];
@@ -406,8 +409,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];
@@ -571,8 +577,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("count" in __overrides) {
     count = __overrides["count"];
@@ -747,8 +756,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("items" in __overrides) {
     items = __overrides["items"];
@@ -911,8 +923,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("value" in __overrides) {
     value = __overrides["value"];

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -1327,7 +1330,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -604,7 +607,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -225,8 +225,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }
@@ -357,8 +360,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -785,7 +788,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];
@@ -372,8 +375,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];
@@ -519,8 +525,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("items" in __overrides) {
     items = __overrides["items"];

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -509,7 +512,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("c" in __overrides) {
     c = __overrides["c"];

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -394,7 +397,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -564,7 +567,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -478,7 +481,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -21,7 +21,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -30,6 +30,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -52,6 +53,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -108,6 +110,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -30,7 +30,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -110,7 +110,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("block" in __overrides) {
     block = __overrides["block"];

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -532,7 +535,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -536,7 +539,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("items" in __overrides) {
     items = __overrides["items"];

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -341,7 +344,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -324,7 +327,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];
@@ -427,8 +430,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -357,7 +360,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -227,8 +227,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -302,7 +305,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -353,7 +356,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -715,7 +718,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -357,7 +360,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(undefined, initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(undefined, initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -359,7 +362,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(undefined, initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(undefined, initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -537,7 +540,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -242,8 +242,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -529,7 +532,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -321,7 +324,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -324,7 +327,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -235,8 +235,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("x" in __overrides) {
     x = __overrides["x"];
@@ -373,8 +376,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];
@@ -532,8 +538,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("a" in __overrides) {
     a = __overrides["a"];

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -888,7 +891,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -332,7 +335,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -424,7 +427,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("age" in __overrides) {
     age = __overrides["age"];

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("r" in __overrides) {
     r = __overrides["r"];

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -293,7 +296,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -319,7 +322,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(undefined, initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(undefined, initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -311,7 +314,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -306,7 +309,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -232,8 +232,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("input" in __overrides) {
     input = __overrides["input"];
@@ -392,8 +395,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -769,7 +772,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -7,7 +7,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -38,6 +39,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -94,6 +96,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -328,7 +331,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -16,7 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -96,7 +96,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -321,7 +324,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -310,7 +313,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -295,7 +298,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -471,7 +474,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -226,8 +226,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("name" in __overrides) {
     name = __overrides["name"];

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -310,7 +313,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -286,7 +289,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -815,7 +818,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -225,8 +225,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -587,7 +590,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -228,8 +228,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("value" in __overrides) {
     value = __overrides["value"];

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -362,7 +365,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -302,7 +305,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -326,7 +329,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -355,7 +358,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -328,7 +331,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -326,7 +329,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -311,7 +314,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -570,7 +573,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -232,8 +232,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("changes" in __overrides) {
     changes = __overrides["changes"];

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -330,7 +333,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -330,7 +333,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -231,8 +231,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
   if ("prefix" in __overrides) {
     prefix = __overrides["prefix"];

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -225,8 +225,11 @@ let __functionCompleted = false;
 // gracefully omits the embedded checkpoint and retry simply becomes a
 // no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx._pendingArgOverrides) {
-  const __overrides = __ctx._pendingArgOverrides;
+if (
+  __ctx._pendingArgOverrides?.moduleId === __stack.moduleId &&
+  __ctx._pendingArgOverrides?.scopeName === __stack.scopeName
+) {
+  const __overrides = __ctx._pendingArgOverrides.values;
   __ctx._pendingArgOverrides = undefined;
 
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -477,7 +480,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -15,7 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
-  resumeFromCheckpoint as _resumeFromCheckpoint,
+  resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -95,7 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
-const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -6,7 +6,7 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
   runExportedFunctionForServe as _runExportedFunctionForServe,
@@ -37,6 +38,7 @@ import {
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,
   createLogger as __createLogger,
+  runCliEntry,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +95,7 @@ function pass() { return { type: "pass" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
 // Invoke an exported function in a node-grade execution frame. Used by
 // `agency serve` to call a function from an HTTP/MCP request — outside any
@@ -326,7 +329,10 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       messages: new ThreadStore(),
       data: {}
     };
-    const __result = await main(undefined, initialState);
+    const __result = await runCliEntry({
+      runMain: () => main(undefined, initialState),
+      resume: __resumeFromCheckpoint
+    });
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     reportBudgetExceededAndExit(__error)


### PR DESCRIPTION
## Summary

- add `agency resume <checkpoint-file> <input.agency>` with local, argument, global, and program argument overrides
- share checkpoint restore preparation across interrupt resume, debugger rewind, and direct CLI resume while preserving the public flat-local `rewindFrom` API
- carry policy, budget, sandbox, model, trace, capture, and other run options through the same child launch path used by `agency run`
- verify checkpoint signatures when a non-empty key is configured and reject changed compiled code
- register entry-module fingerprints before CLI execution so checkpoints created by `main` include code identity
- document the command, integrity rules, lifecycle, carriers, and corrected checkpoint export workflow

## Verification

- `pnpm run typecheck`
- `pnpm run fmt:ts:check`
- `pnpm run lint:structure`
- 198 targeted Vitest tests across runtime, CLI, generated entry, fingerprints, and command parsing
- end-to-end resume spawn tests covering all override buckets, `std::args`, trace footer creation, resumed interrupts, root policy handling, `--agency-only`, and changed-source refusal
- `pnpm run agency test js tests/agency-js/imported-module-callback-rewind`
- `make fixtures`
