### PR TITLE
Pause a run from outside with pauseSignal

### DIFF
--- a/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
+++ b/packages/agency-lang/.claude/skills/agency-runtime-docs/SKILL.md
@@ -15,6 +15,7 @@ Paths are relative to `packages/agency-lang/`. Read the one that matches the tas
 - `docs/dev/runtime/checkpoint-integrity.md` — The optional HMAC checksum embedded in a checkpoint, and how a host verifies it.
 - `docs/dev/runtime/checkpointing.md` — Snapshotting execution state so a program can restore back to it later.
 - `docs/dev/runtime/rewind.md` — Replaying execution from a checkpoint, optionally with different values for its local variables.
+- `docs/dev/runtime/pause.md` — Pausing a node run from outside with `pauseSignal`: the runner check, the thrown signal, which steps defer a pause, cancel precedence, and `resumeFromCheckpoint`.
 - `docs/dev/runtime/resume-command.md` — The `agency resume` child carrier, shared restore setup, overrides, integrity check, and lifecycle.
 - `docs/dev/runtime/trace.md` — Execution traces: a checkpoint per step, written to a file the debugger can replay.
 - `docs/dev/runtime/threads.md` — How LLM conversation history accumulates and flows through thread and subthread blocks.

--- a/packages/agency-lang/CLAUDE.md
+++ b/packages/agency-lang/CLAUDE.md
@@ -246,6 +246,7 @@ Other process docs:
 - `docs/dev/runtime/interrupts.md` — How a program resumes in the middle of a block after an interrupt, using step counters.
 - `docs/dev/runtime/lock.md` — A per-run mutex for serializing access to shared resources such as the terminal prompt.
 - `docs/dev/runtime/rewind.md` — Replaying execution from a checkpoint, optionally with different values for its local variables.
+- `docs/dev/runtime/pause.md` — Pausing a node run from outside with `pauseSignal`: the runner check, the thrown signal, which steps defer a pause, cancel precedence, and `resumeFromCheckpoint`.
 - `docs/dev/runtime/resume-command.md` — The `agency resume` child carrier, shared restore setup, overrides, integrity check, and lifecycle.
 - `docs/dev/runtime/runBatch.md` — The one primitive that owns concurrent-interrupt orchestration for forks, parallel blocks, tool calls, and subprocesses.
 - `docs/dev/runtime/saveDraft.md` — How a scope's best-so-far value survives a guard trip instead of being lost.

--- a/packages/agency-lang/docs/dev/runtime/pause.md
+++ b/packages/agency-lang/docs/dev/runtime/pause.md
@@ -1,0 +1,131 @@
+# Pausing a run from outside
+
+A TypeScript host can stop a running node at a statement boundary, keep its
+state as a checkpoint, and continue it later. The first user is a job runner
+with a Pause button.
+
+```ts
+import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
+
+const pause = new AbortController();
+const result = await main({ pauseSignal: pause.signal });
+// Elsewhere, while main() runs: pause.abort()
+
+if (isPaused(result.data)) {
+  const resumed = await resumeFromCheckpoint(result.data);
+}
+```
+
+`result.data` is a `PausedCheckpoint`: `{ type: "paused", checkpoint, runId }`.
+It is plain JSON, so a host can store it and resume in another process.
+
+## How a pause happens
+
+1. The caller passes `pauseSignal`, a standard `AbortSignal`, to a node export,
+   `respondToInterrupts`, or `resumeFromCheckpoint`. The entry runs its body
+   under `withExternalSignals` (`lib/runtime/externalSignals.ts`). When the
+   signal fires, it sets `execCtx.pauseRequested`. Nothing else happens then.
+   A model call or fetch in flight keeps going.
+2. `Runner.step()` and `Runner.hook()` call `pauseIfRequested` after the
+   guard-trip raise and before the step body. If the context is cancelled,
+   it throws the cancel reason. If the step cannot take a pause (see below),
+   it returns and leaves the flag set. Otherwise it calls `pauseAtStep`
+   (`lib/runtime/pause.ts`).
+3. `pauseAtStep` stamps a checkpoint at this step, logs `checkpointCreated`
+   with reason `pause`, clears the flag, and throws `PauseSignal`. The step
+   counter has not advanced, so a resume runs this statement.
+4. `runNodeCore` and `runResumeLoop` catch the signal and return
+   `pausedReturnObject(execCtx, signal)`. That awaits pending promises, builds
+   the return object, and pauses the trace writer. No `agentEnd` is emitted,
+   because the run is not over.
+
+Handlers are not consulted. A pause is not an interrupt.
+
+`withExternalSignals` detaches both listeners when the body returns or
+throws. A controller that outlives the run holds no reference to it.
+
+## Why a thrown signal
+
+Interrupts halt by returning an `Interrupt[]` that every generated call site
+checks and passes upward. A second value shape would touch generated code
+everywhere. `restore()` already unwinds by throwing `RestoreSignal`, so
+`PauseSignal` shares its base class, `RunControlSignal`.
+
+Every catch site that must let these signals through tests the base class:
+
+1. The generated catch in every function body (`functionCatchFailure.mustache`).
+2. The generated catch in every node body (`typescriptBuilder.ts`).
+3. The `catch` in `__tryCall` (`result.ts`). Before this change a `restore()`
+   inside a `try` became a failed result.
+4. Callback errors in `hooks.ts`.
+5. The thread-end hook in `runner.ts`.
+
+## Steps that cannot take a pause
+
+The flag stays set in each of these cases, and the next step that can take
+the pause does.
+
+- A handler body is executing (`StateStack.hasExecutingHandlers()`). Handlers
+  have no step address, so a checkpoint taken inside one cannot be resumed.
+- A callback body is executing (`isInsideCallback()` in `hooks.ts`), for the
+  same reason.
+- The runner is on a branch stack, or inside a tool call. Tool calls, forks,
+  and parallel blocks run on branch stacks. When a branch raises an interrupt,
+  the join point saves the branch's threads and globals and then stamps the
+  checkpoint against the parent stack. A thrown pause would skip that join,
+  so the pause waits. A pause requested during an `llm()` tool loop lands on
+  the node statement after the `llm()` call.
+- A guard trip is due at the same step. The trip is raised first, so its
+  answer is recorded before the pause lands.
+
+## Resume
+
+`resumeFromCheckpoint` (`lib/runtime/interrupts.ts`) takes the whole
+`PausedCheckpoint`. It refuses a value with no `runId`, and it keeps that id so
+both halves show as one run in statelog.
+
+It calls `runResumeInvocation`, the resume lifecycle it shares with
+`respondToInterrupts`. That goes through `restoreForResume`, which checks code
+fingerprints and installs the root policy handler and budget from the
+`invocation` option. A host that started the run with a per-invocation policy
+passes the same one on every resume, as it does for `respondToInterrupts`.
+
+The loop is `runResumeLoop`, so a resumed run can finish, raise interrupts, or
+pause again. `resumeFromCheckpoint` accepts no overrides. `rewindFrom` exists
+for that, and it does not take the signals.
+
+`resumeCliFromCheckpoint` is a third copy of the resume lifecycle with a
+different ending (trace footer and statelog flush). It does not use
+`runResumeInvocation` yet.
+
+## Cancel and pause together
+
+`abortSignal` and `pauseSignal` can both be passed, and cancel wins:
+
+- If the abort signal is already aborted when the call starts, the call throws
+  `AgencyCancelledError`.
+- If the context is cancelled when a step boundary is reached, the step throws
+  the cancel reason before it looks at the pause flag.
+- If the abort lands while a call is in flight, such as a `sleep`, the call
+  stops and the run unwinds as an `AgencyAbort` with a `userKill` cause.
+
+## Out of scope
+
+Exported functions called through `__invokeFunction` cannot be paused. That
+path never enters `graph.run`, so the state stack has no current node id, and
+`Checkpoint.fromStateStack` refuses to create a checkpoint.
+
+## Tests
+
+- `lib/runtime/runner.test.ts`: the check in `step` and `hook`, the guard trip
+  first, the unchanged step counter, each case that defers, and cancel in both
+  orders.
+- `lib/runtime/externalSignals.test.ts`, `pause.test.ts`, `result.test.ts`,
+  `generatedCatch.test.ts`, `node.pause.test.ts`,
+  `resumeFromCheckpoint.test.ts`.
+- `tests/agency-js/pause-signal-basic`: pause during a sleep, then resume in
+  the same process and in a fresh one from JSON.
+- `tests/agency-js/pause-signal-after-interrupt`: pause and cancel during the
+  leg that `respondToInterrupts` runs.
+- `tests/agency-js/pause-signal-in-tool`, `pause-signal-in-blocks`,
+  `pause-signal-in-callback`, `pause-signal-edges`.

--- a/packages/agency-lang/docs/dev/runtime/pause.md
+++ b/packages/agency-lang/docs/dev/runtime/pause.md
@@ -1,8 +1,7 @@
 # Pausing a run from outside
 
 A TypeScript host can stop a running node at a statement boundary, keep its
-state as a checkpoint, and continue it later. The first user is a job runner
-with a Pause button.
+state as a checkpoint, and continue it later.
 
 ```ts
 import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
@@ -26,23 +25,36 @@ It is plain JSON, so a host can store it and resume in another process.
    under `withExternalSignals` (`lib/runtime/externalSignals.ts`). When the
    signal fires, it sets `execCtx.pauseRequested`. Nothing else happens then.
    A model call or fetch in flight keeps going.
-2. `Runner.step()` and `Runner.hook()` call `pauseIfRequested` after the
-   guard-trip raise and before the step body. If the context is cancelled,
-   it throws the cancel reason. If the step cannot take a pause (see below),
-   it returns and leaves the flag set. Otherwise it calls `pauseAtStep`
-   (`lib/runtime/pause.ts`).
-3. `pauseAtStep` stamps a checkpoint at this step, logs `checkpointCreated`
-   with reason `pause`, clears the flag, and throws `PauseSignal`. The step
-   counter has not advanced, so a resume runs this statement.
-4. `runNodeCore` and `runResumeLoop` catch the signal and return
-   `pausedReturnObject(execCtx, signal)`. That awaits pending promises, builds
-   the return object, and pauses the trace writer. No `agentEnd` is emitted,
-   because the run is not over.
+2. Every runner method that starts a statement calls `pauseIfRequested`:
+   `step`, `hook`, `pipe`, `thread`, `handle`, `ifElse`, `loop`, `whileLoop`,
+   `branchStep`, `fork`, and `debugger`. The call comes after `shouldSkip()`
+   and before the statement does any work. In `step` and `hook` it also comes
+   after the guard-trip raise.
+3. If the context is cancelled, `pauseIfRequested` throws the cancel reason.
+   If the statement cannot take a pause (see below), it returns and leaves the
+   flag set. Otherwise it calls `pauseAtStep` (`lib/runtime/pause.ts`).
+4. `pauseAtStep` awaits pending async calls, stamps a checkpoint at this step,
+   logs `checkpointCreated` with reason `pause`, clears the flag, and throws
+   `PauseSignal`. The step counter has not advanced, so a resume runs this
+   statement.
+5. `runNodeCore` and `runResumeLoop` catch the signal and return
+   `pausedReturnObject(execCtx, signal)`. That builds the return object and
+   pauses the trace writer. No `agentEnd` is emitted, because the run is not
+   over.
 
 Handlers are not consulted. A pause is not an interrupt.
 
 `withExternalSignals` detaches both listeners when the body returns or
 throws. A controller that outlives the run holds no reference to it.
+
+## Why pending async calls are awaited first
+
+An assignment like `const x = async fetchThing()` stores a `Promise` in the
+frame locals. The resolved value reaches the frame only when
+`pendingPromises.awaitAll()` runs the resolver. A promise does not survive
+serialization, so a checkpoint stamped before `awaitAll` would resume without
+the result. The user-facing `checkpoint()` function awaits pending calls for
+the same reason (`lib/runtime/checkpoint.ts`).
 
 ## Why a thrown signal
 
@@ -55,14 +67,14 @@ Every catch site that must let these signals through tests the base class:
 
 1. The generated catch in every function body (`functionCatchFailure.mustache`).
 2. The generated catch in every node body (`typescriptBuilder.ts`).
-3. The `catch` in `__tryCall` (`result.ts`). Before this change a `restore()`
-   inside a `try` became a failed result.
+3. The `catch` in `__tryCall` (`result.ts`), so `try` does not turn a restore
+   or a pause into a failed result.
 4. Callback errors in `hooks.ts`.
 5. The thread-end hook in `runner.ts`.
 
-## Steps that cannot take a pause
+## Statements that cannot take a pause
 
-The flag stays set in each of these cases, and the next step that can take
+The flag stays set in each of these cases, and the next statement that can take
 the pause does.
 
 - A handler body is executing (`StateStack.hasExecutingHandlers()`). Handlers
@@ -74,7 +86,8 @@ the pause does.
   the join point saves the branch's threads and globals and then stamps the
   checkpoint against the parent stack. A thrown pause would skip that join,
   so the pause waits. A pause requested during an `llm()` tool loop lands on
-  the node statement after the `llm()` call.
+  the node statement after the `llm()` call. Issue #1046 tracks letting a
+  pause land inside a branch.
 - A guard trip is due at the same step. The trip is raised first, so its
   answer is recorded before the pause lands.
 
@@ -94,18 +107,14 @@ The loop is `runResumeLoop`, so a resumed run can finish, raise interrupts, or
 pause again. `resumeFromCheckpoint` accepts no overrides. `rewindFrom` exists
 for that, and it does not take the signals.
 
-`resumeCliFromCheckpoint` is a third copy of the resume lifecycle with a
-different ending (trace footer and statelog flush). It does not use
-`runResumeInvocation` yet.
-
 ## Cancel and pause together
 
 `abortSignal` and `pauseSignal` can both be passed, and cancel wins:
 
 - If the abort signal is already aborted when the call starts, the call throws
   `AgencyCancelledError`.
-- If the context is cancelled when a step boundary is reached, the step throws
-  the cancel reason before it looks at the pause flag.
+- If the context is cancelled when a statement starts, the statement throws the
+  cancel reason before it looks at the pause flag.
 - If the abort lands while a call is in flight, such as a `sleep`, the call
   stops and the run unwinds as an `AgencyAbort` with a `userKill` cause.
 
@@ -114,18 +123,3 @@ different ending (trace footer and statelog flush). It does not use
 Exported functions called through `__invokeFunction` cannot be paused. That
 path never enters `graph.run`, so the state stack has no current node id, and
 `Checkpoint.fromStateStack` refuses to create a checkpoint.
-
-## Tests
-
-- `lib/runtime/runner.test.ts`: the check in `step` and `hook`, the guard trip
-  first, the unchanged step counter, each case that defers, and cancel in both
-  orders.
-- `lib/runtime/externalSignals.test.ts`, `pause.test.ts`, `result.test.ts`,
-  `generatedCatch.test.ts`, `node.pause.test.ts`,
-  `resumeFromCheckpoint.test.ts`.
-- `tests/agency-js/pause-signal-basic`: pause during a sleep, then resume in
-  the same process and in a fresh one from JSON.
-- `tests/agency-js/pause-signal-after-interrupt`: pause and cancel during the
-  leg that `respondToInterrupts` runs.
-- `tests/agency-js/pause-signal-in-tool`, `pause-signal-in-blocks`,
-  `pause-signal-in-callback`, `pause-signal-edges`.

--- a/packages/agency-lang/docs/site/guide/interrupts-from-typescript.md
+++ b/packages/agency-lang/docs/site/guide/interrupts-from-typescript.md
@@ -82,3 +82,43 @@ console.log(result.data); // the final return value
 - `reject()` - reject
 - `approve(value)` - approve with a value
 - `reject(reason)` - reject with a reason
+
+## Pausing a run from outside
+
+You can stop a run that is in progress and keep its state, for example when a
+user presses Pause on a background job. Pass a `pauseSignal` when you start the
+run:
+
+```ts
+import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
+
+const pause = new AbortController();
+const result = await main("import the recipes", { pauseSignal: pause.signal });
+```
+
+Call `pause.abort()` while the run is going. The program stops at its next
+statement. A model call or fetch that is already in flight finishes first, and
+so does a tool call the model made. The result has a paused checkpoint in
+`data`:
+
+```ts
+if (isPaused(result.data)) {
+  save(result.data); // plain JSON, safe to store
+}
+```
+
+Continue later, in the same process or another one:
+
+```ts
+const resumed = await resumeFromCheckpoint(saved, { pauseSignal: nextPause.signal });
+```
+
+`resumeFromCheckpoint` returns the same kind of result as `main()`. Check it
+with `isPaused` and `hasInterrupts` the same way. A resumed run refuses to
+continue if the compiled program has changed since the pause. If you started
+the run with a policy in its options, pass the same `invocation` options when
+you resume.
+
+`respondToInterrupts` accepts `pauseSignal` too, so you can pause a run after
+answering its interrupts. Pausing does not call your handlers. If you pass both
+`pauseSignal` and `abortSignal` and both fire, the run is cancelled.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -4436,6 +4436,8 @@ export class TypeScriptBuilder {
                     traceId: ts.id("__invocationTraceId"),
                   }),
                   input: ts.id("__invocationInput"),
+                  abortSignal: ts.id("__invocationAbortSignal"),
+                  pauseSignal: ts.id("__invocationPauseSignal"),
                   initializeGlobals: ts.id("__initializeGlobals"),
                 }),
               ])

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3113,7 +3113,10 @@ export class TypeScriptBuilder {
           ),
         ]),
         ts.statements([
-          ts.if(ts.raw("__error instanceof RestoreSignal"), ts.statements([ts.throw("__error")])),
+          ts.if(
+            ts.raw("__error instanceof RunControlSignal"),
+            ts.statements([ts.throw("__error")]),
+          ),
           // All aborts — cancellations (Esc / abort) AND guard trips — are a
           // single AgencyAbort carrying an AbortCause and must propagate
           // untouched rather than be logged + converted to a Failure here.

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.test.ts
@@ -19,8 +19,17 @@ describe("node wrapper per-invocation options", () => {
 
   it("destructures the options into hidden aliases", () => {
     expect(ts).toContain(
-      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }",
+      "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }",
     );
+  });
+
+  it("types the cancel and pause signals on the options object", () => {
+    expect(ts).toContain("abortSignal?: AbortSignal; pauseSignal?: AbortSignal }");
+  });
+
+  it("forwards the cancel and pause signals to runNode", () => {
+    expect(ts).toContain("abortSignal: __invocationAbortSignal,");
+    expect(ts).toContain("pauseSignal: __invocationPauseSignal,");
   });
 
   it("types the options object with InvocationOptions", () => {

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nodeWrapperParams.ts
@@ -40,10 +40,12 @@ export function nodeWrapperParams(
   // plain one-parameter call and an eval input have the same shape. The key
   // is deliberately not `input`: nodes often have a parameter of that name,
   // and `main(input, { input } = {})` would read as the same value twice.
+  // `abortSignal` and `pauseSignal` are the caller's cancel and pause handles,
+  // passed straight through to `runNode`.
   params.push({
-    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }",
+    name: "{ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }",
     typeAnnotation:
-      "({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions)",
+      "({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions)",
     defaultValue: ts.obj({}),
   });
   return params;

--- a/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
@@ -32,6 +32,13 @@ export function makeMockCtx(
     handlers: [] as any[],
     callbacks: {},
     _skipNextCheckpoint: false,
+    pauseRequested: false,
+    abortController: new AbortController(),
+    throwIfCancelled() {
+      if (this.abortController.signal.aborted) {
+        throw this.abortController.signal.reason;
+      }
+    },
     _toolCallDepth: 0,
     runId: null,
     traceConfig: {},

--- a/packages/agency-lang/lib/runtime/errors.test.ts
+++ b/packages/agency-lang/lib/runtime/errors.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   CheckpointError,
   describeAbortCause,
+  PauseSignal,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AgencyCancelledError,
   isAbortError,
@@ -11,6 +13,7 @@ import {
   type AbortCause,
 } from "./errors.js";
 import { GuardExceededError, isGuardExceededError } from "./guard.js";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
 
 describe("AgencyAbort (unified abort base)", () => {
   it("carries a cause; isAbortError true; readCause returns it", () => {
@@ -252,5 +255,16 @@ describe("describeAbortCause", () => {
     expect(describeAbortCause(makeAbortCause({ kind: "userKill" }))).toBe(
       "Execution aborted (userKill)",
     );
+  });
+});
+
+describe("run-control signals", () => {
+  it("RestoreSignal and PauseSignal share the RunControlSignal base", () => {
+    const cp = makeCheckpoint();
+    expect(new RestoreSignal(cp)).toBeInstanceOf(RunControlSignal);
+    const pause = new PauseSignal(cp);
+    expect(pause).toBeInstanceOf(RunControlSignal);
+    expect(pause.name).toBe("PauseSignal");
+    expect(pause.checkpoint).toBe(cp);
   });
 });

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -44,8 +44,7 @@ export class CheckpointCodeChangedError extends Error {
 }
 
 /** Base for the signals the runtime throws to unwind a whole run on purpose.
- *  Every catch site that must not swallow a `RestoreSignal` tests this base,
- *  so a new signal is covered by the same sites. */
+ *  A catch site that must let a restore or a pause through tests this base. */
 export class RunControlSignal extends Error {}
 
 export class RestoreSignal extends RunControlSignal {

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -43,7 +43,12 @@ export class CheckpointCodeChangedError extends Error {
   }
 }
 
-export class RestoreSignal extends Error {
+/** Base for the signals the runtime throws to unwind a whole run on purpose.
+ *  Every catch site that must not swallow a `RestoreSignal` tests this base,
+ *  so a new signal is covered by the same sites. */
+export class RunControlSignal extends Error {}
+
+export class RestoreSignal extends RunControlSignal {
   checkpoint: Checkpoint;
   options?: RestoreOptions;
 
@@ -52,6 +57,19 @@ export class RestoreSignal extends Error {
     this.name = "RestoreSignal";
     this.checkpoint = checkpoint;
     this.options = options;
+  }
+}
+
+/** Thrown by the runner when an external pause request is honoured at a
+ *  step boundary. Carries the checkpoint stamped at that step. Caught by the
+ *  run entry points, which return it to the caller as a `PausedCheckpoint`. */
+export class PauseSignal extends RunControlSignal {
+  checkpoint: Checkpoint;
+
+  constructor(checkpoint: Checkpoint) {
+    super(`Paused at checkpoint ${checkpoint.id}`);
+    this.name = "PauseSignal";
+    this.checkpoint = checkpoint;
   }
 }
 

--- a/packages/agency-lang/lib/runtime/externalSignals.test.ts
+++ b/packages/agency-lang/lib/runtime/externalSignals.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  attachAbortSignal,
+  attachPauseSignal,
+  withExternalSignals,
+  type SignalTarget,
+} from "./externalSignals.js";
+import { AgencyCancelledError } from "./errors.js";
+
+type FakeTarget = SignalTarget & { cancelled: number };
+
+function fakeTarget(): FakeTarget {
+  const target: FakeTarget = {
+    pauseRequested: false,
+    cancelled: 0,
+    cancel() {
+      target.cancelled++;
+    },
+  };
+  return target;
+}
+
+describe("attachPauseSignal", () => {
+  it("does nothing without a signal and returns a no-op detach", () => {
+    const target = fakeTarget();
+    const detach = attachPauseSignal(target, undefined);
+    detach();
+    expect(target.pauseRequested).toBe(false);
+  });
+
+  it("sets the flag at once for an already-aborted signal", () => {
+    const target = fakeTarget();
+    const ctl = new AbortController();
+    ctl.abort();
+    attachPauseSignal(target, ctl.signal);
+    expect(target.pauseRequested).toBe(true);
+  });
+
+  it("sets the flag when the signal fires later", () => {
+    const target = fakeTarget();
+    const ctl = new AbortController();
+    attachPauseSignal(target, ctl.signal);
+    expect(target.pauseRequested).toBe(false);
+    ctl.abort();
+    expect(target.pauseRequested).toBe(true);
+  });
+
+  it("does nothing after detach", () => {
+    const target = fakeTarget();
+    const ctl = new AbortController();
+    const detach = attachPauseSignal(target, ctl.signal);
+    detach();
+    ctl.abort();
+    expect(target.pauseRequested).toBe(false);
+  });
+});
+
+describe("attachAbortSignal", () => {
+  it("throws AgencyCancelledError for an already-aborted signal", () => {
+    const ctl = new AbortController();
+    ctl.abort();
+    expect(() => attachAbortSignal(fakeTarget(), ctl.signal)).toThrow(AgencyCancelledError);
+  });
+
+  it("cancels the target when the signal fires later", () => {
+    const target = fakeTarget();
+    const ctl = new AbortController();
+    attachAbortSignal(target, ctl.signal);
+    expect(target.cancelled).toBe(0);
+    ctl.abort();
+    expect(target.cancelled).toBe(1);
+  });
+
+  it("does nothing after detach", () => {
+    const target = fakeTarget();
+    const ctl = new AbortController();
+    const detach = attachAbortSignal(target, ctl.signal);
+    detach();
+    ctl.abort();
+    expect(target.cancelled).toBe(0);
+  });
+});
+
+describe("withExternalSignals", () => {
+  it("attaches for the body and detaches after it returns", async () => {
+    const target = fakeTarget();
+    const pause = new AbortController();
+    const cancel = new AbortController();
+    const value = await withExternalSignals(
+      target,
+      { pauseSignal: pause.signal, abortSignal: cancel.signal },
+      async () => {
+        pause.abort();
+        return "done";
+      },
+    );
+    expect(value).toBe("done");
+    expect(target.pauseRequested).toBe(true);
+    cancel.abort();
+    expect(target.cancelled).toBe(0);
+  });
+
+  it("detaches when the body throws", async () => {
+    const target = fakeTarget();
+    const cancel = new AbortController();
+    await expect(
+      withExternalSignals(target, { abortSignal: cancel.signal }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    cancel.abort();
+    expect(target.cancelled).toBe(0);
+  });
+
+  it("throws before the body for an already-aborted abort signal", async () => {
+    const cancel = new AbortController();
+    cancel.abort();
+    let ran = false;
+    await expect(
+      withExternalSignals(fakeTarget(), { abortSignal: cancel.signal }, async () => {
+        ran = true;
+      }),
+    ).rejects.toBeInstanceOf(AgencyCancelledError);
+    expect(ran).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/runtime/externalSignals.ts
+++ b/packages/agency-lang/lib/runtime/externalSignals.ts
@@ -1,0 +1,70 @@
+import { AgencyCancelledError } from "./errors.js";
+
+/** The slice of an execution context the caller's signals act on. */
+export type SignalTarget = {
+  pauseRequested: boolean;
+  cancel: (reason?: string) => void;
+};
+
+/** The two handles a host may pass into a run. */
+export type ExternalSignals = {
+  abortSignal?: AbortSignal;
+  pauseSignal?: AbortSignal;
+};
+
+type Detach = () => void;
+
+const noop: Detach = () => {};
+
+/** Wire a caller's cancel signal to an execution context. An already-aborted
+ *  signal throws at once; a later abort cancels the context, which tears
+ *  down in-flight LLM requests. Returns a detach function the entry calls
+ *  when it returns, so a host controller that outlives the run holds no
+ *  reference to the context. */
+export function attachAbortSignal(target: SignalTarget, signal?: AbortSignal): Detach {
+  if (!signal) {
+    return noop;
+  }
+  if (signal.aborted) {
+    throw new AgencyCancelledError();
+  }
+  const onAbort = () => target.cancel();
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => signal.removeEventListener("abort", onAbort);
+}
+
+/** Wire a caller's pause signal to an execution context. Firing it only sets
+ *  a flag; the runner stops at its next statement boundary. Returns a detach
+ *  function, as attachAbortSignal does. */
+export function attachPauseSignal(target: SignalTarget, signal?: AbortSignal): Detach {
+  if (!signal) {
+    return noop;
+  }
+  if (signal.aborted) {
+    target.pauseRequested = true;
+    return noop;
+  }
+  const onAbort = () => {
+    target.pauseRequested = true;
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => signal.removeEventListener("abort", onAbort);
+}
+
+/** Run `body` with the caller's signals wired to `target`, and unwire them
+ *  however the body ends. This is the only way an entry point attaches
+ *  signals, so no entry can forget the detach. */
+export async function withExternalSignals<T>(
+  target: SignalTarget,
+  signals: ExternalSignals,
+  body: () => Promise<T>,
+): Promise<T> {
+  const detachAbort = attachAbortSignal(target, signals.abortSignal);
+  const detachPause = attachPauseSignal(target, signals.pauseSignal);
+  try {
+    return await body();
+  } finally {
+    detachAbort();
+    detachPause();
+  }
+}

--- a/packages/agency-lang/lib/runtime/externalSignals.ts
+++ b/packages/agency-lang/lib/runtime/externalSignals.ts
@@ -52,8 +52,7 @@ export function attachPauseSignal(target: SignalTarget, signal?: AbortSignal): D
 }
 
 /** Run `body` with the caller's signals wired to `target`, and unwire them
- *  however the body ends. This is the only way an entry point attaches
- *  signals, so no entry can forget the detach. */
+ *  however the body ends. */
 export async function withExternalSignals<T>(
   target: SignalTarget,
   signals: ExternalSignals,

--- a/packages/agency-lang/lib/runtime/generatedCatch.test.ts
+++ b/packages/agency-lang/lib/runtime/generatedCatch.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { compile, resetCompilationCache } from "@/compiler/defaultSession.js";
 import { safeDeleteDirectoryWithin } from "@/utils.js";
+import { isPaused } from "./pause.js";
 
 /**
  * Every generated function and node body wraps its steps in a catch that
@@ -11,11 +12,10 @@ import { safeDeleteDirectoryWithin } from "@/utils.js";
  * must pass through that catch untouched, or a pause inside a `def` would
  * come back as a failed result instead of unwinding the run.
  *
- * The compiled program loads the runtime from `agency-lang/runtime`, a
- * different module instance from the one this test imports, so the
- * assertions compare the error name rather than the class.
+ * The signal is caught where the node run started, which returns it to the
+ * caller as a paused result.
  */
-describe("generated catch blocks re-throw a PauseSignal", () => {
+describe("generated catch blocks let a PauseSignal reach the node entry", () => {
   const fixturesRoot = path.resolve(__dirname, "../../.agency-tmp/generated-catch");
   const mainAgency = path.join(fixturesRoot, "main.agency");
   const mainJs = mainAgency.replace(/\.agency$/, ".js");
@@ -62,11 +62,13 @@ describe("generated catch blocks re-throw a PauseSignal", () => {
 
   it("a PauseSignal thrown inside a def is not converted to a Failure", async () => {
     const mod = await import(pathToFileURL(mainJs).href);
-    await expect(mod.viaFunction()).rejects.toMatchObject({ name: "PauseSignal" });
+    const result = await mod.viaFunction();
+    expect(isPaused(result.data)).toBe(true);
   });
 
   it("a PauseSignal thrown inside a node body is not converted to a Failure", async () => {
     const mod = await import(pathToFileURL(mainJs).href);
-    await expect(mod.viaNode()).rejects.toMatchObject({ name: "PauseSignal" });
+    const result = await mod.viaNode();
+    expect(isPaused(result.data)).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runtime/generatedCatch.test.ts
+++ b/packages/agency-lang/lib/runtime/generatedCatch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { pathToFileURL } from "url";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { compile, resetCompilationCache } from "@/compiler/defaultSession.js";
+import { safeDeleteDirectoryWithin } from "@/utils.js";
+
+/**
+ * Every generated function and node body wraps its steps in a catch that
+ * turns a thrown error into a Failure. A run-control signal (restore, pause)
+ * must pass through that catch untouched, or a pause inside a `def` would
+ * come back as a failed result instead of unwinding the run.
+ *
+ * The compiled program loads the runtime from `agency-lang/runtime`, a
+ * different module instance from the one this test imports, so the
+ * assertions compare the error name rather than the class.
+ */
+describe("generated catch blocks re-throw a PauseSignal", () => {
+  const fixturesRoot = path.resolve(__dirname, "../../.agency-tmp/generated-catch");
+  const mainAgency = path.join(fixturesRoot, "main.agency");
+  const mainJs = mainAgency.replace(/\.agency$/, ".js");
+
+  beforeAll(() => {
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(fixturesRoot, "thrower.js"),
+      'import { PauseSignal, Checkpoint, StateStack, GlobalStore } from "agency-lang/runtime";\n' +
+        "export function throwPause() {\n" +
+        "  const checkpoint = new Checkpoint({\n" +
+        "    stack: new StateStack().toJSON(),\n" +
+        "    globals: new GlobalStore().toJSON(),\n" +
+        '    nodeId: "main",\n' +
+        "  });\n" +
+        "  throw new PauseSignal(checkpoint);\n" +
+        "}\n",
+    );
+    fs.writeFileSync(
+      mainAgency,
+      'import { throwPause } from "./thrower.js"\n' +
+        "\n" +
+        "def inner(): string {\n" +
+        "  throwPause()\n" +
+        '  return "unreachable"\n' +
+        "}\n" +
+        "\n" +
+        "node viaFunction(): string {\n" +
+        "  return inner()\n" +
+        "}\n" +
+        "\n" +
+        "node viaNode(): string {\n" +
+        "  throwPause()\n" +
+        '  return "unreachable"\n' +
+        "}\n",
+    );
+    resetCompilationCache();
+    compile({}, mainAgency);
+  });
+
+  afterAll(() => {
+    safeDeleteDirectoryWithin(path.resolve(__dirname, "../.."), fixturesRoot);
+  });
+
+  it("a PauseSignal thrown inside a def is not converted to a Failure", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    await expect(mod.viaFunction()).rejects.toMatchObject({ name: "PauseSignal" });
+  });
+
+  it("a PauseSignal thrown inside a node body is not converted to a Failure", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    await expect(mod.viaNode()).rejects.toMatchObject({ name: "PauseSignal" });
+  });
+});

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
-import { callHook, invokeCallbacks, registerGlobalHook } from "./hooks.js";
+import { callHook, invokeCallbacks, isInsideCallback, registerGlobalHook } from "./hooks.js";
 import { State, StateStack } from "./state/stateStack.js";
 
 function ctxWithStack(
@@ -296,5 +296,19 @@ describe("invokeCallbacks subprocess forwarding", () => {
     await invokeCallbacks({ ctx, name: "onNodeStart", data: { nodeName: "x" }, stateStack: stack });
     expect(fired).toEqual([{ nodeName: "x" }]); // local callback still fired
     expect(sent).toEqual([{ type: "callback", name: "onNodeStart", data: { nodeName: "x" } }]); // and forwarded
+  });
+});
+
+describe("isInsideCallback", () => {
+  it("is true only while a callback body runs", async () => {
+    expect(isInsideCallback()).toBe(false);
+    let seen = false;
+    const ctx = fakeCtx();
+    ctx.callbacks.onNodeStart = async () => {
+      seen = isInsideCallback();
+    };
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(seen).toBe(true);
+    expect(isInsideCallback()).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -13,7 +13,7 @@ import type { LLMRetryReason } from "./llmRetry.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { agencyStore, getRuntimeContext } from "./asyncContext.js";
 import { sendCallbackToParent } from "./callbackForwarding.js";
-import { AgencyAbort, RestoreSignal } from "./errors.js";
+import { AgencyAbort, RunControlSignal } from "./errors.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { TraceEvent } from "./trace/types.js";
@@ -210,7 +210,7 @@ async function fireWithGuard(
     // AgencyAbort covers BOTH a cancellation and a guard trip — a guard trip
     // raised inside a callback must propagate to its owning guard, not be
     // logged + dropped as a stray JS error (it is not an AgencyCancelledError).
-    if (error instanceof RestoreSignal) throw error;
+    if (error instanceof RunControlSignal) throw error;
     if (error instanceof AgencyAbort) throw error;
     // Real JS errors (e.g. a callback body crashed) are logged and dropped.
     // Callback bodies cannot raise interrupts (typechecker-enforced), so

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -145,6 +145,13 @@ export type AgencyCallbacks = {
 // checkpoint can never capture a "stuck" entry.
 const _activeCallbacksALS = new AsyncLocalStorage<Set<object>>();
 
+/** True while a callback body is executing on this async path. The runner
+ *  defers an external pause here, because a checkpoint taken inside a
+ *  callback dispatch is not a place a resume can re-enter. */
+export function isInsideCallback(): boolean {
+  return _activeCallbacksALS.getStore() !== undefined;
+}
+
 // Global hook registry: allows external packages (e.g., @agency-lang/mcp) to
 // register callbacks that fire alongside user-provided callbacks.
 const _globalHooks: Partial<Record<keyof CallbackMap, Array<(data: any) => any>>> = {};

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -110,11 +110,15 @@ export {
   CheckpointError,
   CheckpointCodeChangedError,
   RestoreSignal,
+  PauseSignal,
+  RunControlSignal,
   AgencyAbort,
   AgencyCancelledError,
   CallDepthExceededError,
   isAbortError,
 } from "./errors.js";
+export { isPaused, pausedResult } from "./pause.js";
+export type { PausedCheckpoint } from "./pause.js";
 export { GuardExceededError, isGuardExceededError } from "./guard.js";
 export { AbortedResult, isAborted, previewForLog } from "./abortedResult.js";
 export type { Guard, GuardJSON } from "./guard.js";

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -85,8 +85,9 @@ export {
   respondToInterrupts,
   respondToInterruptsForServe,
   resumeCliFromCheckpoint,
+  resumeFromCheckpoint,
 } from "./interrupts.js";
-export type { ResumeCliFromCheckpointArgs } from "./interrupts.js";
+export type { ResumeCliFromCheckpointArgs, ResumeFromCheckpointArgs } from "./interrupts.js";
 
 export { checkPolicy, checkPolicyExplicit, validatePolicy } from "./policy.js";
 

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -5,19 +5,28 @@ import { z } from "zod";
 import { approve, reject } from "./interruptResponse.js";
 import type { InterruptApprove, InterruptReject, InterruptResponse } from "./interruptResponse.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
-import { resolveInvocation, type InvocationOptions } from "./invocationOptions.js";
+import {
+  resolveInvocation,
+  type InvocationOptions,
+  type ResolvedInvocation,
+} from "./invocationOptions.js";
 import {
   AgencyCancelledError,
   HandlerRecursionError,
   PauseSignal,
   RestoreSignal,
 } from "./errors.js";
-import { withExternalSignals } from "./externalSignals.js";
-import { pausedReturnObject } from "./pause.js";
+import { withExternalSignals, type ExternalSignals } from "./externalSignals.js";
+import { pausedReturnObject, type PausedCheckpoint } from "./pause.js";
 import { isAborted } from "./abortedResult.js";
 import { throwIfNodeResultAborted } from "./abortBoundary.js";
 import { mergeFor, mergeForIpc } from "./effectMerge.js";
-import { applyRestoreOverrides, restoreForResume, type ResumeOverrides } from "./resumeSetup.js";
+import {
+  applyRestoreOverrides,
+  restoreForResume,
+  type ResumeMetadata,
+  type ResumeOverrides,
+} from "./resumeSetup.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import { RuntimeContext } from "./state/context.js";
 import { GlobalStore, GlobalStoreJSON } from "./state/globalStore.js";
@@ -845,11 +854,53 @@ async function respondToInterruptsCore(
     options: args.invocation,
     runId: interrupt.runId,
   });
+  return runResumeInvocation({
+    ctx,
+    resolved,
+    checkpoint,
+    overrides: { locals: args.overrides },
+    metadata,
+    signals: { abortSignal: args.abortSignal, pauseSignal: args.pauseSignal },
+    afterCheckpointRestored: (execCtx) => {
+      if (isIpcMode()) {
+        return;
+      }
+      for (let i = 0; i < interrupts.length; i++) {
+        const resolvedOutcome = responses[i].type === "approve" ? "approved" : "rejected";
+        execCtx.statelogClient.interruptResolved({
+          interruptId: interrupts[i].interruptId,
+          outcome: resolvedOutcome,
+          resolvedBy: "user",
+        });
+      }
+    },
+    afterRestore: (execCtx) => execCtx.setInterruptResponses(responseMap),
+  });
+}
+
+type ResumeInvocationArgs = {
+  ctx: RuntimeContext<GraphState>;
+  resolved: ResolvedInvocation;
+  checkpoint: Checkpoint;
+  overrides?: ResumeOverrides;
+  metadata?: ResumeMetadata;
+  signals: ExternalSignals;
+  afterCheckpointRestored?: (execCtx: RuntimeContext<GraphState>) => void;
+  afterRestore?: (execCtx: RuntimeContext<GraphState>) => void;
+};
+
+/** The one resume lifecycle shared by interrupt response and checkpoint
+ *  resume: a fresh execution context, restore, the agentRun span, the loop,
+ *  error logging, and the served outcome. The two callers differ only in
+ *  what they do around the restore, which the two callbacks carry.
+ *
+ *  A single lifecycle boundary covers all resume setup AND execution, so a
+ *  setup failure still yields an outcome-with-usage and still runs cleanup. */
+async function runResumeInvocation(
+  args: ResumeInvocationArgs,
+): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
+  const { ctx, resolved, checkpoint, metadata = {}, signals } = args;
   const execCtx = await ctx.createExecutionContext(resolved);
-  // === Invocation started (context exists): a SINGLE lifecycle boundary covers
-  // all resume setup AND execution, so a setup failure still yields an
-  // outcome-with-usage and still runs cleanup. reinstallRootBudget and handler
-  // registration order are preserved. ===
   const agentStartTime = performance.now();
   let agentRunSpanId: ReturnType<typeof execCtx.statelogClient.startSpan> | undefined;
   let outcome: RawOutcome<RunNodeResult<any>>;
@@ -857,28 +908,14 @@ async function respondToInterruptsCore(
     await restoreForResume(execCtx, {
       checkpoint,
       policy: resolved.policy,
-      overrides: { locals: args.overrides },
+      overrides: args.overrides,
       metadata,
-      afterCheckpointRestored: () => {
-        if (!isIpcMode()) {
-          for (let i = 0; i < interrupts.length; i++) {
-            const intr = interrupts[i];
-            const resp = responses[i];
-            const resolvedOutcome = resp.type === "approve" ? "approved" : ("rejected" as const);
-            execCtx.statelogClient.interruptResolved({
-              interruptId: intr.interruptId,
-              outcome: resolvedOutcome,
-              resolvedBy: "user",
-            });
-          }
-        }
-      },
+      afterCheckpointRestored: () => args.afterCheckpointRestored?.(execCtx),
     });
-    execCtx.setInterruptResponses(responseMap);
+    args.afterRestore?.(execCtx);
 
     agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
     execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
-    const signals = { abortSignal: args.abortSignal, pauseSignal: args.pauseSignal };
     const value = await withExternalSignals(execCtx, signals, () =>
       runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime),
     );
@@ -900,6 +937,42 @@ async function respondToInterruptsCore(
   // Resume tears down with cleanup() (no memory-save/statelog-flush — that is
   // the fresh-run path's finalizeExecCtx); wrap it to match the cleanup shape.
   return finishServedInvocation(execCtx, outcome, async () => execCtx.cleanup());
+}
+
+export type ResumeFromCheckpointArgs = {
+  ctx: RuntimeContext<GraphState>;
+  paused: PausedCheckpoint;
+  metadata?: ResumeMetadata;
+  abortSignal?: AbortSignal;
+  pauseSignal?: AbortSignal;
+  // Per-invocation config and root policy for this resume leg, with the same
+  // contract as respondToInterrupts: the paused runId is kept, and a host that
+  // started the run with a policy passes the same one here.
+  invocation?: InvocationOptions;
+};
+
+/** Continue a run that an external pause stopped. Keeps the paused run's id,
+ *  checks code fingerprints, reinstalls the root policy and budget, and runs
+ *  the same loop as an interrupt response, so the result can again be a
+ *  value, interrupts, or another paused checkpoint. Takes no overrides; a
+ *  caller who wants to change a local uses rewindFrom. */
+export async function resumeFromCheckpoint(args: ResumeFromCheckpointArgs): Promise<any> {
+  if (!args.paused.runId) {
+    throw new Error("Cannot resume: the paused value has no run id");
+  }
+  const resolved = resolveInvocation({
+    kind: "resume",
+    options: args.invocation,
+    runId: args.paused.runId,
+  });
+  const served = await runResumeInvocation({
+    ctx: args.ctx,
+    resolved,
+    checkpoint: deepClone(args.paused.checkpoint),
+    metadata: args.metadata,
+    signals: { abortSignal: args.abortSignal, pauseSignal: args.pauseSignal },
+  });
+  return unwrapServedInvocationOutcome(served);
 }
 
 /** Public entry point — unchanged contract: returns the resume result or throws

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -6,7 +6,14 @@ import { approve, reject } from "./interruptResponse.js";
 import type { InterruptApprove, InterruptReject, InterruptResponse } from "./interruptResponse.js";
 import { runInBootstrapFrame } from "./asyncContext.js";
 import { resolveInvocation, type InvocationOptions } from "./invocationOptions.js";
-import { AgencyCancelledError, HandlerRecursionError, RestoreSignal } from "./errors.js";
+import {
+  AgencyCancelledError,
+  HandlerRecursionError,
+  PauseSignal,
+  RestoreSignal,
+} from "./errors.js";
+import { withExternalSignals } from "./externalSignals.js";
+import { pausedReturnObject } from "./pause.js";
 import { isAborted } from "./abortedResult.js";
 import { throwIfNodeResultAborted } from "./abortBoundary.js";
 import { mergeFor, mergeForIpc } from "./effectMerge.js";
@@ -730,6 +737,9 @@ async function runResumeLoop(
       }
       return returnObject;
     } catch (e) {
+      if (e instanceof PauseSignal) {
+        return await pausedReturnObject(execCtx, e);
+      }
       if (e instanceof RestoreSignal) {
         const cp = e.checkpoint;
         execCtx._restoreCount++;
@@ -804,6 +814,9 @@ type RespondToInterruptsArgs = {
   // original interrupt.runId and ignores any supplied traceId; only the config
   // projection is applied.
   invocation?: InvocationOptions;
+  // The caller's cancel and pause handles for this resume leg.
+  abortSignal?: AbortSignal;
+  pauseSignal?: AbortSignal;
 };
 
 async function respondToInterruptsCore(
@@ -865,7 +878,10 @@ async function respondToInterruptsCore(
 
     agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
     execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
-    const value = await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);
+    const signals = { abortSignal: args.abortSignal, pauseSignal: args.pauseSignal };
+    const value = await withExternalSignals(execCtx, signals, () =>
+      runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime),
+    );
     outcome = { status: "returned", value };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/agency-lang/lib/runtime/node.pause.test.ts
+++ b/packages/agency-lang/lib/runtime/node.pause.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { pathToFileURL } from "url";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { compile, resetCompilationCache } from "@/compiler/defaultSession.js";
+import { safeDeleteDirectoryWithin } from "@/utils.js";
+import { isPaused } from "./pause.js";
+
+describe("a generated node export accepts pauseSignal and abortSignal", () => {
+  const fixturesRoot = path.resolve(__dirname, "../../.agency-tmp/node-pause");
+  const mainAgency = path.join(fixturesRoot, "main.agency");
+  const mainJs = mainAgency.replace(/\.agency$/, ".js");
+
+  beforeAll(() => {
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    fs.writeFileSync(
+      mainAgency,
+      "node main(): number {\n" +
+        "  let total = 0\n" +
+        "  total = total + 1\n" +
+        "  total = total + 1\n" +
+        "  return total\n" +
+        "}\n",
+    );
+    resetCompilationCache();
+    compile({}, mainAgency);
+  });
+
+  afterAll(() => {
+    safeDeleteDirectoryWithin(path.resolve(__dirname, "../.."), fixturesRoot);
+  });
+
+  it("returns a PausedCheckpoint in data when the signal is already aborted", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    const ctl = new AbortController();
+    ctl.abort();
+    const result = await mod.main({ pauseSignal: ctl.signal });
+    expect(isPaused(result.data)).toBe(true);
+    expect(result.data.runId.length).toBeGreaterThan(0);
+    expect(result.data.checkpoint.nodeId).toBe("main");
+  });
+
+  it("resumes a paused run to the value an unpaused run returns", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    const ctl = new AbortController();
+    ctl.abort();
+    const paused = await mod.main({ pauseSignal: ctl.signal });
+    const resumed = await mod.resumeFromCheckpoint(paused.data);
+    expect(resumed.data).toBe(2);
+  });
+
+  it("throws AgencyCancelledError, not a paused result, when both signals are already aborted", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    const cancel = new AbortController();
+    const pause = new AbortController();
+    cancel.abort();
+    pause.abort();
+    await expect(
+      mod.main({ pauseSignal: pause.signal, abortSignal: cancel.signal }),
+    ).rejects.toThrow(/cancelled/);
+  });
+
+  it("detaches its listeners when the run finishes", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    const pause = new AbortController();
+    const cancel = new AbortController();
+    const removePause = vi.spyOn(pause.signal, "removeEventListener");
+    const removeCancel = vi.spyOn(cancel.signal, "removeEventListener");
+    const result = await mod.main({ pauseSignal: pause.signal, abortSignal: cancel.signal });
+    expect(result.data).toBe(2);
+    expect(removePause).toHaveBeenCalledTimes(1);
+    expect(removeCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -6,7 +6,9 @@ import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { AgencyFunction } from "./agencyFunction.js";
-import { AgencyCancelledError, CheckpointError, RestoreSignal } from "./errors.js";
+import { CheckpointError, PauseSignal, RestoreSignal } from "./errors.js";
+import { withExternalSignals } from "./externalSignals.js";
+import { pausedReturnObject } from "./pause.js";
 import { applyRestoreOverrides } from "./resumeSetup.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -346,7 +348,13 @@ type RunNodeArgs = {
   initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
   // An AbortSignal for cancelling the agent mid-execution. When aborted,
   // in-flight LLM requests are torn down and an AgencyCancelledError is thrown.
+  // See pauseSignal for the case where the work should be kept.
   abortSignal?: AbortSignal;
+  // An AbortSignal that asks the run to pause. Firing it stops the program
+  // at its next statement boundary and returns a PausedCheckpoint in `data`.
+  // Work already in flight (an LLM call, a fetch) finishes first. If both
+  // signals fire, cancel wins.
+  pauseSignal?: AbortSignal;
   // Per-invocation config override + optional root trace id for this run.
   invocation?: InvocationOptions;
   // What the entry node was given, when the caller names it (an eval input).
@@ -364,6 +372,7 @@ async function runNodeCore({
   callbacks,
   initializeGlobals,
   abortSignal,
+  pauseSignal,
   invocation,
   input,
 }: RunNodeArgs): Promise<ServedInvocationOutcome<RunNodeResult<any>>> {
@@ -407,98 +416,37 @@ async function runNodeCore({
       Object.assign(execCtx.callbacks, callbacks);
     }
 
-    // Wire external abort signal to the execution context
     const cancel = (reason?: string) => execCtx.cancel(reason);
-    if (abortSignal) {
-      if (abortSignal.aborted) {
-        throw new AgencyCancelledError();
-      }
-      abortSignal.addEventListener("abort", () => execCtx.cancel(), {
-        once: true,
-      });
-    }
+    outcome = await withExternalSignals(execCtx, { abortSignal, pauseSignal }, async () => {
+      // onAgentStart fires BEFORE any agent node has executed, so there is
+      // no real per-run ThreadStore yet — use a bootstrap frame so user
+      // callbacks that reach for thread/message builtins get a clear error
+      // instead of writing into a placeholder. `messages` is still
+      // available to the callback via `data.messages`.
+      await runInBootstrapFrame(execCtx, () =>
+        callHook({
+          ctx: execCtx,
+          name: "onAgentStart",
+          data: { nodeName, args: data, messages: messages || [], cancel },
+        }),
+      );
 
-    // onAgentStart fires BEFORE any agent node has executed, so there is
-    // no real per-run ThreadStore yet — use a bootstrap frame so user
-    // callbacks that reach for thread/message builtins get a clear error
-    // instead of writing into a placeholder. `messages` is still
-    // available to the callback via `data.messages`.
-    await runInBootstrapFrame(execCtx, () =>
-      callHook({
-        ctx: execCtx,
-        name: "onAgentStart",
-        data: { nodeName, args: data, messages: messages || [], cancel },
-      }),
-    );
+      agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
+      execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data, input });
 
-    agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
-    execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data, input });
-
-    let isResume = false;
-    let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
-    while (true) {
-      try {
-        // Install an initial AsyncLocalStorage frame so stdlib helpers
-        // that read `getRuntimeContext()` (the post-migration replacement
-        // for the `__ctx, __stateStack, __threads` codegen-injected
-        // args) see a sensible context even on code paths that run
-        // outside a Runner-managed step. Generated function and node
-        // bodies re-enter `agencyStore.run` inside each Runner step with
-        // the scope-local stack/threads, so this top-level frame is just
-        // the fallback for early code (callHook, validation, etc.).
-        const result = await agencyStore.run(
-          {
-            ctx: execCtx,
-            stack: execCtx.stateStack,
-            threads: threadStore,
-            globals: execCtx.globals,
-          },
-          () =>
-            execCtx.graph.run(
-              nodeName,
-              {
-                messages: threadStore,
-                data,
-                ctx: execCtx,
-                isResume,
-              },
-              {
-                onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
-                statelogClient: execCtx.statelogClient,
-              },
-            ),
-        );
-        await execCtx.pendingPromises.awaitAll();
-
-        await throwIfNodeResultAborted(result, execCtx, { endsRun: true });
-
-        const returnObject = createReturnObject({
-          result,
-          globals: execCtx.globals,
-        });
-
-        if (hasInterrupts(returnObject.data)) {
-          // Interrupt(s): attach runId and pause (no footer)
-          if (execCtx.runId) {
-            // eslint-disable-next-line max-depth -- attaching runId to each interrupt
-            for (const intr of returnObject.data) {
-              intr.runId = execCtx.runId;
-            }
-          }
-          await execCtx.pauseTraceWriter();
-        } else {
-          // Final result: emit footer and close
-          execCtx.statelogClient.agentEnd({
-            entryNode: nodeName,
-            result: returnObject.data,
-            timeTaken: performance.now() - agentStartTime,
-            tokenStats: returnObject.tokens,
-          });
-          // onAgentEnd fires AFTER the run finished, so seed ALS with
-          // the real per-run ThreadStore: user callbacks that inspect
-          // the final conversation through stdlib helpers see the
-          // actual messages, not a sentinel.
-          await agencyStore.run(
+      let isResume = false;
+      let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+      while (true) {
+        try {
+          // Install an initial AsyncLocalStorage frame so stdlib helpers
+          // that read `getRuntimeContext()` (the post-migration replacement
+          // for the `__ctx, __stateStack, __threads` codegen-injected
+          // args) see a sensible context even on code paths that run
+          // outside a Runner-managed step. Generated function and node
+          // bodies re-enter `agencyStore.run` inside each Runner step with
+          // the scope-local stack/threads, so this top-level frame is just
+          // the fallback for early code (callHook, validation, etc.).
+          const result = await agencyStore.run(
             {
               ctx: execCtx,
               stack: execCtx.stateStack,
@@ -506,47 +454,102 @@ async function runNodeCore({
               globals: execCtx.globals,
             },
             () =>
-              callHook({
-                ctx: execCtx,
-                name: "onAgentEnd",
-                data: { nodeName, result: returnObject },
-              }),
+              execCtx.graph.run(
+                nodeName,
+                {
+                  messages: threadStore,
+                  data,
+                  ctx: execCtx,
+                  isResume,
+                },
+                {
+                  onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
+                  statelogClient: execCtx.statelogClient,
+                },
+              ),
           );
-          await execCtx.closeTraceWriter();
-        }
-        outcome = { status: "returned", value: returnObject };
-        break;
-      } catch (e) {
-        if (e instanceof RestoreSignal) {
-          execCtx._restoreCount++;
-          if (execCtx._restoreCount > execCtx.maxRestores) {
-            throw new CheckpointError(
-              `Exceeded maximum number of restores (${execCtx.maxRestores}). Possible infinite loop.`,
-            );
-          }
-          const cp = e.checkpoint;
-          execCtx.statelogClient.checkpointRestored({
-            checkpointId: cp.id,
-            restoreCount: execCtx._restoreCount,
-            maxRestores: execCtx.maxRestores,
-            overrides: {
-              args: !!e.options?.args,
-              globals: !!e.options?.globals,
-            },
+          await execCtx.pendingPromises.awaitAll();
+
+          await throwIfNodeResultAborted(result, execCtx, { endsRun: true });
+
+          const returnObject = createReturnObject({
+            result,
+            globals: execCtx.globals,
           });
-          execCtx.restoreState(cp);
-          applyRestoreOverrides(execCtx, cp, e.options);
-          nodeName = cp.nodeId;
-          data = {};
-          isResume = true;
-          execCtx.stateStack.nodesTraversed = [cp.nodeId];
-          // Reset ThreadStore for the restored execution
-          threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
-          continue;
+
+          if (hasInterrupts(returnObject.data)) {
+            // Interrupt(s): attach runId and pause (no footer)
+            if (execCtx.runId) {
+              // eslint-disable-next-line max-depth -- attaching runId to each interrupt
+              for (const intr of returnObject.data) {
+                intr.runId = execCtx.runId;
+              }
+            }
+            await execCtx.pauseTraceWriter();
+          } else {
+            // Final result: emit footer and close
+            execCtx.statelogClient.agentEnd({
+              entryNode: nodeName,
+              result: returnObject.data,
+              timeTaken: performance.now() - agentStartTime,
+              tokenStats: returnObject.tokens,
+            });
+            // onAgentEnd fires AFTER the run finished, so seed ALS with
+            // the real per-run ThreadStore: user callbacks that inspect
+            // the final conversation through stdlib helpers see the
+            // actual messages, not a sentinel.
+            await agencyStore.run(
+              {
+                ctx: execCtx,
+                stack: execCtx.stateStack,
+                threads: threadStore,
+                globals: execCtx.globals,
+              },
+              () =>
+                callHook({
+                  ctx: execCtx,
+                  name: "onAgentEnd",
+                  data: { nodeName, result: returnObject },
+                }),
+            );
+            await execCtx.closeTraceWriter();
+          }
+          return { status: "returned" as const, value: returnObject };
+        } catch (e) {
+          if (e instanceof PauseSignal) {
+            return { status: "returned" as const, value: await pausedReturnObject(execCtx, e) };
+          }
+          if (e instanceof RestoreSignal) {
+            execCtx._restoreCount++;
+            if (execCtx._restoreCount > execCtx.maxRestores) {
+              throw new CheckpointError(
+                `Exceeded maximum number of restores (${execCtx.maxRestores}). Possible infinite loop.`,
+              );
+            }
+            const cp = e.checkpoint;
+            execCtx.statelogClient.checkpointRestored({
+              checkpointId: cp.id,
+              restoreCount: execCtx._restoreCount,
+              maxRestores: execCtx.maxRestores,
+              overrides: {
+                args: !!e.options?.args,
+                globals: !!e.options?.globals,
+              },
+            });
+            execCtx.restoreState(cp);
+            applyRestoreOverrides(execCtx, cp, e.options);
+            nodeName = cp.nodeId;
+            data = {};
+            isResume = true;
+            execCtx.stateStack.nodesTraversed = [cp.nodeId];
+            // Reset ThreadStore for the restored execution
+            threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+            continue;
+          }
+          throw e;
         }
-        throw e;
       }
-    }
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     execCtx.statelogClient.error({

--- a/packages/agency-lang/lib/runtime/pause.test.ts
+++ b/packages/agency-lang/lib/runtime/pause.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { isPaused, pausedResult } from "./pause.js";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
+
+describe("isPaused", () => {
+  it("recognises a paused result", () => {
+    const cp = makeCheckpoint();
+    const paused = pausedResult(cp, "run-1");
+    expect(paused).toEqual({ type: "paused", checkpoint: cp, runId: "run-1" });
+    expect(isPaused(paused)).toBe(true);
+  });
+
+  it("rejects everything that is not a paused result", () => {
+    const cp = makeCheckpoint();
+    expect(isPaused(cp)).toBe(false);
+    expect(isPaused([{ type: "interrupt" }])).toBe(false);
+    expect(isPaused(null)).toBe(false);
+    expect(isPaused("paused")).toBe(false);
+    expect(isPaused({ type: "paused", checkpoint: null, runId: "r" })).toBe(false);
+    expect(isPaused({ type: "paused", checkpoint: [], runId: "r" })).toBe(false);
+    expect(isPaused({ type: "paused", checkpoint: cp, runId: "" })).toBe(false);
+    expect(isPaused({ type: "paused", checkpoint: cp })).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/runtime/pause.ts
+++ b/packages/agency-lang/lib/runtime/pause.ts
@@ -1,0 +1,18 @@
+import type { Checkpoint } from "./state/checkpointStore.js";
+import { pausedCheckpointSchema } from "./state/schemas.js";
+
+/** What a run returns in `data` when a pause request stopped it. The host
+ *  stores the whole value and hands it back to `resumeFromCheckpoint`. */
+export type PausedCheckpoint = {
+  type: "paused";
+  checkpoint: Checkpoint;
+  runId: string;
+};
+
+export function pausedResult(checkpoint: Checkpoint, runId: string): PausedCheckpoint {
+  return { type: "paused", checkpoint, runId };
+}
+
+export function isPaused(data: unknown): data is PausedCheckpoint {
+  return pausedCheckpointSchema.safeParse(data).success;
+}

--- a/packages/agency-lang/lib/runtime/pause.ts
+++ b/packages/agency-lang/lib/runtime/pause.ts
@@ -47,10 +47,17 @@ type PauseAtStepArgs = {
   location: SourceLocationOpts;
 };
 
-/** Honour an external pause at a step boundary: stamp a checkpoint here,
- *  record it, clear the request, and unwind with PauseSignal. The step
- *  counter has not advanced, so a resume re-enters this same statement. */
-export function pauseAtStep({ ctx, stack, location }: PauseAtStepArgs): never {
+/** Honour an external pause at a step boundary: settle pending async calls,
+ *  stamp a checkpoint here, record it, clear the request, and unwind with
+ *  PauseSignal. The step counter has not advanced, so a resume re-enters
+ *  this same statement.
+ *
+ *  An async call keeps its result in a pending-promise resolver, not in the
+ *  frame, so the checkpoint is stamped only after `awaitAll` has written
+ *  those results into the frame locals. */
+export async function pauseAtStep({ ctx, stack, location }: PauseAtStepArgs): Promise<never> {
+  await ctx.pendingPromises.awaitAll();
+  ctx.throwIfCancelled();
   const checkpointId = ctx.checkpoints.create(stack, ctx, location);
   const checkpoint = ctx.checkpoints.get(checkpointId);
   if (!checkpoint) {

--- a/packages/agency-lang/lib/runtime/pause.ts
+++ b/packages/agency-lang/lib/runtime/pause.ts
@@ -3,6 +3,8 @@ import type { Checkpoint, SourceLocationOpts } from "./state/checkpointStore.js"
 import type { RuntimeContext } from "./state/context.js";
 import { pausedCheckpointSchema } from "./state/schemas.js";
 import type { StateStack } from "./state/stateStack.js";
+import type { RunNodeResult } from "./types.js";
+import { createReturnObject } from "./utils.js";
 
 /** What a run returns in `data` when a pause request stopped it. The host
  *  stores the whole value and hands it back to `resumeFromCheckpoint`. */
@@ -18,6 +20,25 @@ export function pausedResult(checkpoint: Checkpoint, runId: string): PausedCheck
 
 export function isPaused(data: unknown): data is PausedCheckpoint {
   return pausedCheckpointSchema.safeParse(data).success;
+}
+
+/** Settle a caught pause into the object the caller gets back. The run is
+ *  not over, so the trace writer is paused rather than closed, and the
+ *  entry that catches the signal emits no agentEnd. */
+export async function pausedReturnObject(
+  execCtx: RuntimeContext<any>,
+  signal: PauseSignal,
+): Promise<RunNodeResult<PausedCheckpoint>> {
+  if (!execCtx.runId) {
+    throw new Error("Paused run has no run id");
+  }
+  await execCtx.pendingPromises.awaitAll();
+  const returnObject = createReturnObject({
+    result: { data: pausedResult(signal.checkpoint, execCtx.runId) },
+    globals: execCtx.globals,
+  });
+  await execCtx.pauseTraceWriter();
+  return returnObject;
 }
 
 type PauseAtStepArgs = {

--- a/packages/agency-lang/lib/runtime/pause.ts
+++ b/packages/agency-lang/lib/runtime/pause.ts
@@ -1,5 +1,8 @@
-import type { Checkpoint } from "./state/checkpointStore.js";
+import { PauseSignal } from "./errors.js";
+import type { Checkpoint, SourceLocationOpts } from "./state/checkpointStore.js";
+import type { RuntimeContext } from "./state/context.js";
 import { pausedCheckpointSchema } from "./state/schemas.js";
+import type { StateStack } from "./state/stateStack.js";
 
 /** What a run returns in `data` when a pause request stopped it. The host
  *  stores the whole value and hands it back to `resumeFromCheckpoint`. */
@@ -15,4 +18,28 @@ export function pausedResult(checkpoint: Checkpoint, runId: string): PausedCheck
 
 export function isPaused(data: unknown): data is PausedCheckpoint {
   return pausedCheckpointSchema.safeParse(data).success;
+}
+
+type PauseAtStepArgs = {
+  ctx: RuntimeContext<any>;
+  stack: StateStack;
+  location: SourceLocationOpts;
+};
+
+/** Honour an external pause at a step boundary: stamp a checkpoint here,
+ *  record it, clear the request, and unwind with PauseSignal. The step
+ *  counter has not advanced, so a resume re-enters this same statement. */
+export function pauseAtStep({ ctx, stack, location }: PauseAtStepArgs): never {
+  const checkpointId = ctx.checkpoints.create(stack, ctx, location);
+  const checkpoint = ctx.checkpoints.get(checkpointId);
+  if (!checkpoint) {
+    throw new Error(`Pause checkpoint ${checkpointId} was not stored`);
+  }
+  ctx.statelogClient.checkpointCreated({
+    checkpointId,
+    reason: "pause",
+    sourceLocation: location,
+  });
+  ctx.pauseRequested = false;
+  throw new PauseSignal(checkpoint);
 }

--- a/packages/agency-lang/lib/runtime/result.test.ts
+++ b/packages/agency-lang/lib/runtime/result.test.ts
@@ -13,7 +13,15 @@ import {
   guardFailureMessage,
   type ResultFailure,
 } from "./result.js";
-import { AgencyAbort, AgencyCancelledError, makeAbortCause, type AbortCause } from "./errors.js";
+import {
+  AgencyAbort,
+  AgencyCancelledError,
+  makeAbortCause,
+  PauseSignal,
+  RestoreSignal,
+  type AbortCause,
+} from "./errors.js";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
 import { AbortedResult } from "./abortedResult.js";
 import { State } from "./state/stateStack.js";
 
@@ -552,5 +560,25 @@ describe("a Result built by hand in imported TypeScript", () => {
   it("leaves a success alone", async () => {
     const ok = { __type: "resultType", success: true, value: 42 };
     expect(await __tryCall(() => ok)).toBe(ok);
+  });
+});
+
+describe("__tryCall — run-control signals", () => {
+  it("re-throws a RestoreSignal instead of turning it into a failure", async () => {
+    const cp = makeCheckpoint();
+    await expect(
+      __tryCall(async () => {
+        throw new RestoreSignal(cp);
+      }),
+    ).rejects.toBeInstanceOf(RestoreSignal);
+  });
+
+  it("re-throws a PauseSignal instead of turning it into a failure", async () => {
+    const cp = makeCheckpoint();
+    await expect(
+      __tryCall(async () => {
+        throw new PauseSignal(cp);
+      }),
+    ).rejects.toBeInstanceOf(PauseSignal);
   });
 });

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isAbortError, readCause } from "./errors.js";
+import { isAbortError, readCause, RunControlSignal } from "./errors.js";
 import { truncate } from "./truncate.js";
 import { isAborted } from "./abortedResult.js";
 import { hasInterrupts } from "./interrupts.js";
@@ -318,6 +318,11 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
     if (resultValueSchema.safeParse(value).success) return normalizeForeignResult(value);
     return success(value);
   } catch (error) {
+    // A restore or a pause unwinds the whole run on purpose. It is not a
+    // failure of the tried call, so it must not become a Failure here.
+    if (error instanceof RunControlSignal) {
+      throw error;
+    }
     // Cancellation must always propagate — never get silently
     // converted into a Failure value. A `try fetch(...)` whose
     // underlying request was aborted by Ctrl-C, race-loser cleanup,

--- a/packages/agency-lang/lib/runtime/resumeFromCheckpoint.test.ts
+++ b/packages/agency-lang/lib/runtime/resumeFromCheckpoint.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { RuntimeContext } from "./state/context.js";
+import { resumeFromCheckpoint } from "./interrupts.js";
+import { CheckpointCodeChangedError } from "./errors.js";
+import { makeCheckpoint } from "./checkpointTestHelpers.js";
+import { installRunPolicyHandler } from "./runPolicyHandler.js";
+
+vi.mock("./runPolicyHandler.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./runPolicyHandler.js")>();
+  return { ...original, installRunPolicyHandler: vi.fn(original.installRunPolicyHandler) };
+});
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+}
+
+describe("resumeFromCheckpoint", () => {
+  afterEach(() => {
+    vi.mocked(installRunPolicyHandler).mockClear();
+  });
+
+  it("refuses a checkpoint whose module fingerprints no longer match", async () => {
+    const cp = makeCheckpoint();
+    cp.moduleFingerprints = { "mod-that-changed": { hash: "stale", compiledAt: "then" } };
+    await expect(
+      resumeFromCheckpoint({
+        ctx: makeCtx(),
+        paused: { type: "paused", checkpoint: cp, runId: "run-1" },
+      }),
+    ).rejects.toBeInstanceOf(CheckpointCodeChangedError);
+  });
+
+  it("refuses a paused value with no run id", async () => {
+    const cp = makeCheckpoint();
+    await expect(
+      resumeFromCheckpoint({
+        ctx: makeCtx(),
+        paused: { type: "paused", checkpoint: cp, runId: "" },
+      }),
+    ).rejects.toThrow(/run id/);
+  });
+
+  it("installs the policy passed in the invocation options", async () => {
+    const policy = { "std::env": [{ action: "reject" as const }] };
+    // The empty checkpoint has no graph to run, so the resume fails after the
+    // restore. The assertion is on the install, which happens during restore.
+    await resumeFromCheckpoint({
+      ctx: makeCtx(),
+      paused: { type: "paused", checkpoint: makeCheckpoint(), runId: "run-1" },
+      invocation: { policy },
+    }).catch(() => undefined);
+    expect(installRunPolicyHandler).toHaveBeenCalledWith(expect.anything(), policy);
+  });
+});

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -7,7 +7,8 @@ import { ThreadStore } from "./state/threadStore.js";
 import { getRuntimeContext, runInTestContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { TimeGuard } from "./guard.js";
-import { readCause } from "./errors.js";
+import { AgencyCancelledError, PauseSignal, readCause } from "./errors.js";
+import { callHook } from "./hooks.js";
 import * as smoltalk from "smoltalk";
 import { ABANDONED_TURN_TEXT } from "./threadRepair.js";
 import type { MessageThread } from "./state/messageThread.js";
@@ -1258,5 +1259,113 @@ describe("custom redaction markers across both statelog paths", () => {
     runtimeContext.globals.markRedacted(secret);
     const output = JSON.stringify({ secret }, makeRedactReplacer(runtimeContext.globals));
     expect(JSON.parse(output as string)).toEqual({ secret: "[REDACTED]" });
+  });
+});
+
+describe("Runner — external pause", () => {
+  it("throws PauseSignal before the step body when a pause is requested", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    let ran = false;
+    let caught: unknown;
+    try {
+      await runner.step(0, async () => {
+        ran = true;
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(ran).toBe(false);
+    expect(caught).toBeInstanceOf(PauseSignal);
+    const cp = (caught as PauseSignal).checkpoint;
+    expect(cp.stepPath).toBe("0");
+    expect(ctx.pauseRequested).toBe(false);
+    expect(ctx.checkpoints.get(cp.id)).toBe(cp);
+  });
+
+  it("checks for a pause in hook() too", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    let ran = false;
+    await expect(
+      runner.hook(0, async () => {
+        ran = true;
+      }),
+    ).rejects.toBeInstanceOf(PauseSignal);
+    expect(ran).toBe(false);
+  });
+
+  it("does not advance the step counter, so a resume re-enters the same step", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const frame = makeFrame();
+    const runner = new Runner(ctx, frame, { stack: new StateStack() });
+    await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(PauseSignal);
+    expect(frame.step).toBe(0);
+  });
+
+  it("lets a pending guard trip raise first", async () => {
+    vi.useFakeTimers();
+    try {
+      const stack = new StateStack();
+      stack.pushGuard(new TimeGuard(20));
+      vi.advanceTimersByTime(20);
+      const ctx = makeMockCtx();
+      ctx.pauseRequested = true;
+      const runner = new Runner(ctx, makeFrame(), { stack });
+      await runner.step(0, async () => {});
+      expect(runner.halted).toBe(true);
+      expect(runner.haltResult[0].effect).toBe("std::guard");
+      expect(ctx.pauseRequested).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defers the pause while a handler body is executing", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const stack = new StateStack();
+    stack.executingHandlerEntries.push({ fn: async () => undefined, liveGuardIds: [] });
+    const runner = new Runner(ctx, makeFrame(), { stack });
+    let ran = false;
+    await runner.step(0, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(ctx.pauseRequested).toBe(true);
+  });
+
+  it("defers the pause while a callback body is executing", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    let ran = false;
+    ctx.callbacks.onNodeStart = async () => {
+      await runner.step(0, async () => {
+        ran = true;
+      });
+    };
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } });
+    expect(ran).toBe(true);
+    expect(ctx.pauseRequested).toBe(true);
+  });
+
+  it("cancel wins when the context is aborted and a pause is requested", async () => {
+    const ctx = makeMockCtx();
+    ctx.abortController.abort(new AgencyCancelledError("stop"));
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(AgencyCancelledError);
+  });
+
+  it("cancel wins in the other order: pause requested, then aborted", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    ctx.abortController.abort(new AgencyCancelledError("stop"));
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(AgencyCancelledError);
   });
 });

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1378,6 +1378,51 @@ describe("Runner — external pause", () => {
     expect(ctx.pauseRequested).toBe(true);
   });
 
+  it("settles pending async results before stamping the checkpoint", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const frame = ctx.stateStack.stack[0];
+    ctx.pendingPromises.add(Promise.resolve("async value"), (value: unknown) => {
+      frame.locals.asyncResult = value;
+    });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
+    const caught = await runner.step(0, async () => {}).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(PauseSignal);
+    const checkpoint = (caught as PauseSignal).checkpoint;
+    expect(checkpoint.stack.stack[0].locals.asyncResult).toBe("async value");
+  });
+
+  it("checks for a pause before an if statement evaluates its condition", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
+    let evaluated = false;
+    const branches = [
+      {
+        condition: () => {
+          evaluated = true;
+          return true;
+        },
+        body: async () => {},
+      },
+    ];
+    await expect(runner.ifElse(0, branches)).rejects.toBeInstanceOf(PauseSignal);
+    expect(evaluated).toBe(false);
+  });
+
+  it("checks for a pause before a for loop reads its items", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
+    let read = false;
+    const items = () => {
+      read = true;
+      return [1];
+    };
+    await expect(runner.loop(0, items, async () => {})).rejects.toBeInstanceOf(PauseSignal);
+    expect(read).toBe(false);
+  });
+
   it("cancel wins when the context is aborted and a pause is requested", async () => {
     const ctx = makeMockCtx();
     ctx.abortController.abort(new AgencyCancelledError("stop"));

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1266,7 +1266,7 @@ describe("Runner — external pause", () => {
   it("throws PauseSignal before the step body when a pause is requested", async () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
-    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
     let ran = false;
     let caught: unknown;
     try {
@@ -1287,7 +1287,7 @@ describe("Runner — external pause", () => {
   it("checks for a pause in hook() too", async () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
-    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
     let ran = false;
     await expect(
       runner.hook(0, async () => {
@@ -1301,7 +1301,7 @@ describe("Runner — external pause", () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
     const frame = makeFrame();
-    const runner = new Runner(ctx, frame, { stack: new StateStack() });
+    const runner = new Runner(ctx, frame, { stack: ctx.stateStack });
     await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(PauseSignal);
     expect(frame.step).toBe(0);
   });
@@ -1309,10 +1309,10 @@ describe("Runner — external pause", () => {
   it("lets a pending guard trip raise first", async () => {
     vi.useFakeTimers();
     try {
-      const stack = new StateStack();
+      const ctx = makeMockCtx();
+      const stack = ctx.stateStack;
       stack.pushGuard(new TimeGuard(20));
       vi.advanceTimersByTime(20);
-      const ctx = makeMockCtx();
       ctx.pauseRequested = true;
       const runner = new Runner(ctx, makeFrame(), { stack });
       await runner.step(0, async () => {});
@@ -1327,7 +1327,7 @@ describe("Runner — external pause", () => {
   it("defers the pause while a handler body is executing", async () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
-    const stack = new StateStack();
+    const stack = ctx.stateStack;
     stack.executingHandlerEntries.push({ fn: async () => undefined, liveGuardIds: [] });
     const runner = new Runner(ctx, makeFrame(), { stack });
     let ran = false;
@@ -1341,7 +1341,7 @@ describe("Runner — external pause", () => {
   it("defers the pause while a callback body is executing", async () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
-    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
     let ran = false;
     ctx.callbacks.onNodeStart = async () => {
       await runner.step(0, async () => {
@@ -1353,11 +1353,36 @@ describe("Runner — external pause", () => {
     expect(ctx.pauseRequested).toBe(true);
   });
 
+  it("defers the pause on a branch stack, such as a tool call or fork branch", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    let ran = false;
+    await runner.step(0, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(ctx.pauseRequested).toBe(true);
+  });
+
+  it("defers the pause inside a tool call", async () => {
+    const ctx = makeMockCtx();
+    ctx.pauseRequested = true;
+    ctx.enterToolCall();
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
+    let ran = false;
+    await runner.step(0, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(ctx.pauseRequested).toBe(true);
+  });
+
   it("cancel wins when the context is aborted and a pause is requested", async () => {
     const ctx = makeMockCtx();
     ctx.abortController.abort(new AgencyCancelledError("stop"));
     ctx.pauseRequested = true;
-    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
     await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(AgencyCancelledError);
   });
 
@@ -1365,7 +1390,7 @@ describe("Runner — external pause", () => {
     const ctx = makeMockCtx();
     ctx.pauseRequested = true;
     ctx.abortController.abort(new AgencyCancelledError("stop"));
-    const runner = new Runner(ctx, makeFrame(), { stack: new StateStack() });
+    const runner = new Runner(ctx, makeFrame(), { stack: ctx.stateStack });
     await expect(runner.step(0, async () => {})).rejects.toBeInstanceOf(AgencyCancelledError);
   });
 });

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -3,7 +3,7 @@ import { nanoid } from "nanoid";
 import { __globals, agencyStore } from "./asyncContext.js";
 import { raiseGuardTripsAtStep } from "./guardTripInterrupt.js";
 import { debugStep } from "./debugger.js";
-import { RestoreSignal, readCause } from "./errors.js";
+import { RunControlSignal, readCause } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
 import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
@@ -787,7 +787,7 @@ export class Runner {
             // primary exception. `fireWithGuard` inside invokeCallbacks
             // already logs JS errors; this catch is belt-and-braces for
             // unexpected throws from the dispatcher itself.
-            if (e instanceof RestoreSignal) throw e;
+            if (e instanceof RunControlSignal) throw e;
             // Surface the failure as a structured statelog event so it
             // shows up in traces (replaces the prior bare console.error).
             // Optional chaining: older test contexts may construct a

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -381,7 +381,7 @@ export class Runner {
    *    branches join, after the join saves branch threads and globals. A
    *    thrown pause skips that join, so its checkpoint could not resume.
    *  See pauseAtStep for what a pause does. */
-  private pauseIfRequested(id: number): void {
+  private async pauseIfRequested(id: number): Promise<void> {
     if (!this.ctx.pauseRequested) {
       return;
     }
@@ -393,7 +393,7 @@ export class Runner {
     if (stack.hasExecutingHandlers() || isInsideCallback()) {
       return;
     }
-    pauseAtStep({
+    await pauseAtStep({
       ctx: this.ctx,
       stack,
       location: {
@@ -528,8 +528,8 @@ export class Runner {
     // replay-safe by construction, because on resume the same boundary
     // re-raises and applies the recorded answer before the body runs.
     if (await this.maybeRaiseGuardTrip(id)) return;
-    this.pauseIfRequested(id);
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
 
     if (await this.maybeDebugHook(id)) return;
@@ -578,8 +578,8 @@ export class Runner {
     // loop-body statements and function-start hooks execute through, so
     // a time trip during a tight loop is detected here.
     if (await this.maybeRaiseGuardTrip(id)) return;
-    this.pauseIfRequested(id);
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
 
     this.ctx.coverageCollector?.hit(this.moduleId, this.scopeName, this.stepPath(id));
@@ -598,6 +598,7 @@ export class Runner {
   async debugger(id: number, label: string): Promise<void> {
     this.beforeStep();
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
     if (await this.maybeDebugHook(id, label, true)) return;
 
@@ -611,6 +612,7 @@ export class Runner {
   async pipe(id: number, input: any, fn: (value: any) => any): Promise<any> {
     this.beforeStep();
     if (this.shouldSkip()) return input;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id)
       return this.frame.locals[`__pipe_result_${this.stepPath(id)}`] ?? input;
 
@@ -657,6 +659,7 @@ export class Runner {
     // need named-args behaviour.
     this.beforeStep();
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
 
     if (await this.maybeDebugHook(id)) return;
@@ -850,6 +853,7 @@ export class Runner {
     callback: (runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     // A COMPLETED handle block returns here, before pushHandler — its
     // scope is over and its handler stays gone on replay. This line is
     // also why the guard-set memo below cannot be keyed by counting
@@ -913,6 +917,7 @@ export class Runner {
     // The top skip stays OUTSIDE the try: when we skip here an OUTER construct
     // owns the pending flag, so we must not clear it.
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     try {
       if (this.getCounter() > id) return;
 
@@ -987,6 +992,7 @@ export class Runner {
     callback: (item: any, second: any, runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
 
     if (await this.maybeDebugHook(id)) return;
@@ -1075,6 +1081,7 @@ export class Runner {
     callback: (runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) return;
 
     if (await this.maybeDebugHook(id)) return;
@@ -1136,6 +1143,7 @@ export class Runner {
     callback: (runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
+    await this.pauseIfRequested(id);
 
     // Enter if: counter hasn't passed this OR branch data exists (resuming async)
     const hasExistingBranch = this.frame.getBranch(branchKey) !== undefined;
@@ -1193,6 +1201,7 @@ export class Runner {
   ): Promise<any> {
     this.beforeStep();
     if (this.shouldSkip()) return undefined;
+    await this.pauseIfRequested(id);
     if (this.getCounter() > id) {
       return this.frame.locals[this.forkResultKey(id)];
     }

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -5,8 +5,9 @@ import { raiseGuardTripsAtStep } from "./guardTripInterrupt.js";
 import { debugStep } from "./debugger.js";
 import { RunControlSignal, readCause } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
-import { invokeCallbacks } from "./hooks.js";
+import { invokeCallbacks, isInsideCallback } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
+import { pauseAtStep } from "./pause.js";
 import { __pipeBind } from "./result.js";
 import { nativeTypeReplacer, nativeTypeReviver } from "./revivers/index.js";
 import { runBatch } from "./runBatch.js";
@@ -370,6 +371,31 @@ export class Runner {
     });
   }
 
+  /** Cancel wins over a pause; otherwise honour a pending pause request at
+   *  this step. A pause may land only outside handler and callback
+   *  dispatch, because a checkpoint taken inside either cannot be resumed.
+   *  The flag stays set and the next ordinary step takes it. See
+   *  pauseAtStep for what a pause does. */
+  private pauseIfRequested(id: number): void {
+    if (!this.ctx.pauseRequested) {
+      return;
+    }
+    this.ctx.throwIfCancelled();
+    const stack = this.stack;
+    if (!stack || stack.hasExecutingHandlers() || isInsideCallback()) {
+      return;
+    }
+    pauseAtStep({
+      ctx: this.ctx,
+      stack,
+      location: {
+        moduleId: this.moduleId,
+        scopeName: this.scopeName,
+        stepPath: this.stepPath(id),
+      },
+    });
+  }
+
   // ── Debug hook ──
 
   /**
@@ -494,6 +520,7 @@ export class Runner {
     // replay-safe by construction, because on resume the same boundary
     // re-raises and applies the recorded answer before the body runs.
     if (await this.maybeRaiseGuardTrip(id)) return;
+    this.pauseIfRequested(id);
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
 
@@ -543,6 +570,7 @@ export class Runner {
     // loop-body statements and function-start hooks execute through, so
     // a time trip during a tight loop is detected here.
     if (await this.maybeRaiseGuardTrip(id)) return;
+    this.pauseIfRequested(id);
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -372,17 +372,25 @@ export class Runner {
   }
 
   /** Cancel wins over a pause; otherwise honour a pending pause request at
-   *  this step. A pause may land only outside handler and callback
-   *  dispatch, because a checkpoint taken inside either cannot be resumed.
-   *  The flag stays set and the next ordinary step takes it. See
-   *  pauseAtStep for what a pause does. */
+   *  this step. The flag stays set, and the next step that can take it
+   *  does, when this step is:
+   *  - inside a handler or callback body, which has no step address a
+   *    resume can re-enter;
+   *  - on a branch stack (a tool call, fork, or parallel block). Interrupts
+   *    from a branch are re-stamped against the parent stack where the
+   *    branches join, after the join saves branch threads and globals. A
+   *    thrown pause skips that join, so its checkpoint could not resume.
+   *  See pauseAtStep for what a pause does. */
   private pauseIfRequested(id: number): void {
     if (!this.ctx.pauseRequested) {
       return;
     }
     this.ctx.throwIfCancelled();
     const stack = this.stack;
-    if (!stack || stack.hasExecutingHandlers() || isInsideCallback()) {
+    if (!stack || stack !== this.ctx.stateStack || this.ctx.isInsideToolCall()) {
+      return;
+    }
+    if (stack.hasExecutingHandlers() || isInsideCallback()) {
       return;
     }
     pauseAtStep({

--- a/packages/agency-lang/lib/runtime/state/context.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.test.ts
@@ -208,3 +208,12 @@ describe("RuntimeContext memory frames", () => {
     expect(execCtx.getActiveMemoryManager()).toBeUndefined();
   });
 });
+
+describe("throwIfCancelled", () => {
+  it("throws the recorded cancel reason and otherwise returns", () => {
+    const ctx = makeMockCtx();
+    expect(() => ctx.throwIfCancelled()).not.toThrow();
+    ctx.cancel("stop");
+    expect(() => ctx.throwIfCancelled()).toThrow(AgencyCancelledError);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -115,6 +115,9 @@ export class RuntimeContext<T> {
   pendingPromises: PendingPromiseStore;
   graph: SimpleMachine<T>;
   _skipNextCheckpoint: boolean;
+  /** Set by an external pause signal. The runner honours it at the next
+   *  step boundary by stamping a checkpoint and throwing PauseSignal. */
+  pauseRequested: boolean;
   _pendingArgOverrides?: PendingArgOverrides;
   _restoreCount: number;
 
@@ -323,6 +326,7 @@ export class RuntimeContext<T> {
     // checkpoint to the trace (the user already saw the rewound checkpoint).
     // rewindFrom sets this flag so the first debugStep trace-write is skipped.
     this._skipNextCheckpoint = false;
+    this.pauseRequested = false;
     this._restoreCount = 0;
     this._toolCallDepth = 0;
     this.pendingPromises = new PendingPromiseStore();
@@ -460,6 +464,7 @@ export class RuntimeContext<T> {
     execCtx.lockWaiters = {};
     execCtx.lockReleasers = {};
     execCtx._skipNextCheckpoint = false;
+    execCtx.pauseRequested = false;
     execCtx._restoreCount = 0;
     execCtx._toolCallDepth = 0;
     execCtx._interruptResponses = {};
@@ -714,6 +719,14 @@ export class RuntimeContext<T> {
     if (!this.abortController.signal.aborted) {
       const resolvedCause = cause ?? makeAbortCause({ kind: "userKill", reason });
       this.abortController.abort(new AgencyCancelledError(reason, resolvedCause));
+    }
+  }
+
+  /** Throw the cancel reason `cancel()` recorded, if the run is cancelled.
+   *  The runner calls this at a step boundary so cancel wins over a pause. */
+  throwIfCancelled(): void {
+    if (this.abortController.signal.aborted) {
+      throw this.abortController.signal.reason;
     }
   }
 

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -112,8 +112,7 @@ export const checkpointSchema = z.object({
   signature: z.string().optional(),
 });
 
-/** The value a paused run returns in `data`. Validated the way a Result
- *  value is in result.ts: one schema, one safeParse. */
+/** The value a paused run returns in `data`. */
 export const pausedCheckpointSchema = z.object({
   type: z.literal("paused"),
   checkpoint: checkpointSchema,

--- a/packages/agency-lang/lib/runtime/state/schemas.ts
+++ b/packages/agency-lang/lib/runtime/state/schemas.ts
@@ -111,3 +111,11 @@ export const checkpointSchema = z.object({
     .optional(),
   signature: z.string().optional(),
 });
+
+/** The value a paused run returns in `data`. Validated the way a Result
+ *  value is in result.ts: one schema, one safeParse. */
+export const pausedCheckpointSchema = z.object({
+  type: z.literal("paused"),
+  checkpoint: checkpointSchema,
+  runId: z.string().min(1),
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.executingHandlers.test.ts
@@ -47,3 +47,26 @@ describe("StateStack.executingHandlerEntries", () => {
     expect(() => stack.assertNoExecutingHandlers()).toThrow(/handler function is executing/);
   });
 });
+
+describe("StateStack.hasExecutingHandlers", () => {
+  it("is false on a clean stack with frames", () => {
+    const stack = new StateStack();
+    stack.stack.push(new State());
+    expect(stack.hasExecutingHandlers()).toBe(false);
+  });
+
+  it("is true when the top-level list is non-empty", () => {
+    const stack = new StateStack();
+    stack.executingHandlerEntries.push(entry());
+    expect(stack.hasExecutingHandlers()).toBe(true);
+  });
+
+  it("finds a mark on a nested branch under an unmarked parent", () => {
+    const stack = new StateStack();
+    const frame = new State();
+    stack.stack.push(frame);
+    const branch = frame.newBranch("tool_x");
+    branch.stack.executingHandlerEntries.push(entry());
+    expect(stack.hasExecutingHandlers()).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -486,15 +486,11 @@ export class StateStack {
     if (this.executingHandlerEntries.length > 0) {
       return true;
     }
-    let found = false;
+    const branchStacks: StateStack[] = [];
     for (const frame of this.stack) {
-      frame.forEachBranchStack((branchStack) => {
-        if (branchStack.hasExecutingHandlers()) {
-          found = true;
-        }
-      });
+      frame.forEachBranchStack((branchStack) => branchStacks.push(branchStack));
     }
-    return found;
+    return branchStacks.some((branchStack) => branchStack.hasExecutingHandlers());
   }
 
   /** Throw if any handler is executing (see hasExecutingHandlers). Called

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -477,23 +477,36 @@ export class StateStack {
     this.executingHandlerEntries = [...parent.executingHandlerEntries];
   }
 
-  /** Throw if any handler is executing on this stack or any branch
-   *  under it. Called at the interrupt-pause checkpoint sites: handlers
-   *  have no step address, so a pause taken mid-handler could never be
-   *  resumed. Walks branches because a mark can live on a branch stack
-   *  whose parent is unmarked (a tool-call branch created inside a
+  /** True if any handler is executing on this stack or any branch under
+   *  it. Handlers have no step address, so a pause taken mid-handler could
+   *  never be resumed. Walks branches because a mark can live on a branch
+   *  stack whose parent is unmarked (a tool-call branch created inside a
    *  handler). */
-  assertNoExecutingHandlers(): void {
+  hasExecutingHandlers(): boolean {
     if (this.executingHandlerEntries.length > 0) {
+      return true;
+    }
+    let found = false;
+    for (const frame of this.stack) {
+      frame.forEachBranchStack((branchStack) => {
+        if (branchStack.hasExecutingHandlers()) {
+          found = true;
+        }
+      });
+    }
+    return found;
+  }
+
+  /** Throw if any handler is executing (see hasExecutingHandlers). Called
+   *  at the interrupt-pause checkpoint sites. */
+  assertNoExecutingHandlers(): void {
+    if (this.hasExecutingHandlers()) {
       throw new Error(
         "Cannot pause the run while a handler function is executing: " +
           "handlers have no step address, so this checkpoint could never " +
           "be resumed. This is a runtime bug — an in-handler pause path " +
           "was reached. See issue #616.",
       );
-    }
-    for (const frame of this.stack) {
-      frame.forEachBranchStack((branchStack) => branchStack.assertNoExecutingHandlers());
     }
   }
 

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1140,7 +1140,7 @@ export class StatelogClient {
     sourceLocation,
   }: {
     checkpointId: number;
-    reason: "interrupt" | "explicit" | "failure" | "fork" | "race";
+    reason: "interrupt" | "explicit" | "failure" | "fork" | "race" | "pause";
     sourceLocation?: { moduleId: string; scopeName: string; stepPath: string };
   }): Promise<void> {
     await this.post({

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
@@ -1,4 +1,4 @@
-if (__error instanceof RestoreSignal) {
+if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
@@ -3,7 +3,7 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `if (__error instanceof RestoreSignal) {
+export const template = `if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -58,10 +58,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -55,8 +57,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -26,6 +26,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -63,10 +63,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -11,15 +11,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -60,8 +62,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/agent.agency
@@ -1,0 +1,11 @@
+import { bump, bumpCount } from "./counter.js"
+
+effect test::gate { step: number }
+
+node main(): number {
+  raise test::gate("ok to continue?", { step: 1 })
+  bump()
+  sleep(400ms)
+  bump()
+  return bumpCount()
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/counter.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/counter.js
@@ -1,0 +1,11 @@
+let bumps = 0;
+export function bump() {
+  bumps = bumps + 1;
+  return bumps;
+}
+export function bumpCount() {
+  return bumps;
+}
+export function reset() {
+  bumps = 0;
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/fixture.json
@@ -1,0 +1,7 @@
+{
+  "interrupted": true,
+  "pausedInResponseLeg": true,
+  "bumpsAtPause": 1,
+  "final": 2,
+  "cancelledInResponseLeg": true
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-after-interrupt/test.js
@@ -1,0 +1,43 @@
+import { main, isPaused, hasInterrupts, approve, respondToInterrupts, resumeFromCheckpoint } from "./agent.js";
+import { bumpCount, reset } from "./counter.js";
+import { writeFileSync } from "fs";
+
+// A cancel that lands before the run starts throws AgencyCancelledError; one
+// that lands mid-run unwinds as an AgencyAbort with a userKill cause.
+const CANCEL_ERRORS = ["AgencyCancelledError", "AgencyAbort"];
+
+const PAUSE_AFTER_MS = 150; // fires inside the program's 400ms sleep
+
+// Interrupt, then pause during the response leg.
+reset();
+const first = await main();
+const interrupted = hasInterrupts(first.data);
+const pause = new AbortController();
+setTimeout(() => pause.abort(), PAUSE_AFTER_MS);
+const second = interrupted
+  ? await respondToInterrupts(first.data, first.data.map(() => approve()), { pauseSignal: pause.signal })
+  : first;
+const pausedInResponseLeg = isPaused(second.data);
+const bumpsAtPause = bumpCount();
+const final = pausedInResponseLeg ? await resumeFromCheckpoint(second.data) : second;
+
+// Interrupt, then cancel during the response leg.
+reset();
+const again = await main();
+const cancel = new AbortController();
+setTimeout(() => cancel.abort(), PAUSE_AFTER_MS);
+let cancelledInResponseLeg = false;
+try {
+  await respondToInterrupts(again.data, again.data.map(() => approve()), { abortSignal: cancel.signal });
+} catch (e) {
+  cancelledInResponseLeg = !!e && CANCEL_ERRORS.includes(e.name);
+}
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { interrupted, pausedInResponseLeg, bumpsAtPause, final: final.data, cancelledInResponseLeg },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/pause-signal-basic/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-basic/agent.agency
@@ -1,0 +1,11 @@
+import { bump, bumpCount } from "./counter.js"
+
+node main(): number {
+  sleep(50ms)
+  bump()
+  sleep(400ms)
+  bump()
+  sleep(50ms)
+  bump()
+  return bumpCount()
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-basic/counter.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-basic/counter.js
@@ -1,0 +1,8 @@
+let bumps = 0;
+export function bump() {
+  bumps = bumps + 1;
+  return bumps;
+}
+export function bumpCount() {
+  return bumps;
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-basic/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-basic/fixture.json
@@ -1,0 +1,6 @@
+{
+  "pausedFirst": true,
+  "bumpsAtPause": 1,
+  "sameProcess": { "finished": 3, "interrupted": false },
+  "freshProcess": { "finished": 2, "pausedAgain": false }
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-basic/resume-stage.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-basic/resume-stage.js
@@ -1,0 +1,9 @@
+import { resumeFromCheckpoint, isPaused } from "./agent.js";
+import { readFileSync, writeFileSync } from "fs";
+
+const paused = JSON.parse(readFileSync("paused.json", "utf8"));
+const result = await resumeFromCheckpoint(paused);
+writeFileSync(
+  "fresh-result.json",
+  JSON.stringify({ finished: result.data, pausedAgain: isPaused(result.data) }),
+);

--- a/packages/agency-lang/tests/agency-js/pause-signal-basic/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-basic/test.js
@@ -1,0 +1,39 @@
+import { main, isPaused, hasInterrupts, resumeFromCheckpoint } from "./agent.js";
+import { bumpCount } from "./counter.js";
+import { writeFileSync, readFileSync, rmSync } from "fs";
+import { execFileSync } from "child_process";
+
+const PAUSE_AFTER_MS = 200; // fires inside the program's 400ms sleep
+
+rmSync("paused.json", { force: true });
+rmSync("fresh-result.json", { force: true });
+
+const pause = new AbortController();
+setTimeout(() => pause.abort(), PAUSE_AFTER_MS);
+const first = await main({ pauseSignal: pause.signal });
+const pausedFirst = isPaused(first.data);
+const bumpsAtPause = bumpCount();
+
+// Resume in this process.
+const resumed = pausedFirst ? await resumeFromCheckpoint(first.data) : first;
+
+// Resume the same paused value in a fresh process, from JSON on disk.
+writeFileSync("paused.json", JSON.stringify(first.data));
+execFileSync(process.execPath, ["./resume-stage.js"], { stdio: "inherit" });
+const fresh = JSON.parse(readFileSync("fresh-result.json", "utf8"));
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      pausedFirst,
+      bumpsAtPause,
+      sameProcess: { finished: resumed.data, interrupted: hasInterrupts(resumed.data) },
+      freshProcess: fresh,
+    },
+    null,
+    2,
+  ),
+);
+rmSync("paused.json", { force: true });
+rmSync("fresh-result.json", { force: true });

--- a/packages/agency-lang/tests/agency-js/pause-signal-edges/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-edges/agent.agency
@@ -1,0 +1,8 @@
+import { bump, bumpCount } from "./counter.js"
+
+node main(): number {
+  bump()
+  sleep(300ms)
+  bump()
+  return bumpCount()
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-edges/counter.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-edges/counter.js
@@ -1,0 +1,11 @@
+let bumps = 0;
+export function bump() {
+  bumps = bumps + 1;
+  return bumps;
+}
+export function bumpCount() {
+  return bumps;
+}
+export function reset() {
+  bumps = 0;
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-edges/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-edges/fixture.json
@@ -1,0 +1,7 @@
+{
+  "pausedAtStart": true,
+  "firstFinished": 2,
+  "lateIgnored": true,
+  "cancelWon": true,
+  "pausedTwice": true
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-edges/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-edges/test.js
@@ -1,0 +1,56 @@
+import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
+import { bumpCount, reset } from "./counter.js";
+import { writeFileSync } from "fs";
+
+// A cancel that lands before the run starts throws AgencyCancelledError; one
+// that lands mid-run unwinds as an AgencyAbort with a userKill cause.
+const CANCEL_ERRORS = ["AgencyCancelledError", "AgencyAbort"];
+
+const FIRE_AFTER_MS = 100; // fires inside the program's 300ms sleep
+
+// 1. A signal already aborted before the call pauses at the first statement.
+reset();
+const early = new AbortController();
+early.abort();
+const r1 = await main({ pauseSignal: early.signal });
+const pausedAtStart = isPaused(r1.data) && bumpCount() === 0;
+const r1Done = pausedAtStart ? await resumeFromCheckpoint(r1.data) : r1;
+
+// 2. Firing the signal after the call returned changes nothing.
+reset();
+const late = new AbortController();
+const r2 = await main({ pauseSignal: late.signal });
+late.abort();
+const lateIgnored = !isPaused(r2.data);
+
+// 3. Both signals fired during a sleep: cancel wins and the call throws.
+reset();
+const cancel = new AbortController();
+const pause = new AbortController();
+setTimeout(() => {
+  pause.abort();
+  cancel.abort();
+}, FIRE_AFTER_MS);
+let cancelWon = false;
+try {
+  await main({ pauseSignal: pause.signal, abortSignal: cancel.signal });
+} catch (e) {
+  cancelWon = !!e && CANCEL_ERRORS.includes(e.name);
+}
+
+// 4. A resumed run can be paused again.
+reset();
+const again = new AbortController();
+again.abort();
+const r4 = await main({ pauseSignal: again.signal });
+const r4b = await resumeFromCheckpoint(r4.data, { pauseSignal: again.signal });
+const pausedTwice = isPaused(r4b.data);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { pausedAtStart, firstFinished: r1Done.data, lateIgnored, cancelWon, pausedTwice },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/agent.agency
@@ -1,0 +1,21 @@
+effect test::gate { step: number }
+
+def gated(): string {
+  raise test::gate("ok to continue?", { step: 1 })
+  return "continued"
+}
+
+def slow(): number {
+  sleep(400ms)
+  return 1
+}
+
+node main(): string {
+  const r = try slow()
+  let out = ""
+  handle {
+    sleep(400ms)
+    out = gated()
+  } with approve
+  return out
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/fixture.json
@@ -1,0 +1,6 @@
+{
+  "pausedInTry": true,
+  "pausedInHandle": true,
+  "final": "continued",
+  "leakedInterrupt": false
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-blocks/test.js
@@ -1,0 +1,27 @@
+import { main, isPaused, hasInterrupts, resumeFromCheckpoint } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const PAUSE_AFTER_MS = 150; // fires inside each 400ms sleep
+
+const p1 = new AbortController();
+setTimeout(() => p1.abort(), PAUSE_AFTER_MS);
+const first = await main({ pauseSignal: p1.signal });
+const pausedInTry = isPaused(first.data);
+
+const p2 = new AbortController();
+setTimeout(() => p2.abort(), PAUSE_AFTER_MS);
+const second = pausedInTry ? await resumeFromCheckpoint(first.data, { pauseSignal: p2.signal }) : first;
+const pausedInHandle = isPaused(second.data);
+
+const final = pausedInHandle ? await resumeFromCheckpoint(second.data) : second;
+
+// If the `with approve` handler were not registered again on resume, the
+// raise inside gated() would come back as an interrupt instead of a value.
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { pausedInTry, pausedInHandle, final: final.data, leakedInterrupt: hasInterrupts(final.data) },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-callback/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-callback/agent.agency
@@ -1,0 +1,17 @@
+import { bump, bumpCount } from "./counter.js"
+
+callback("onFunctionStart") {
+  sleep(400ms)
+  bump()
+}
+
+def work(): number {
+  bump()
+  return 1
+}
+
+node main(): number {
+  work()
+  bump()
+  return bumpCount()
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-callback/counter.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-callback/counter.js
@@ -1,0 +1,11 @@
+let bumps = 0;
+export function bump() {
+  bumps = bumps + 1;
+  return bumps;
+}
+export function bumpCount() {
+  return bumps;
+}
+export function reset() {
+  bumps = 0;
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-callback/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-callback/fixture.json
@@ -1,0 +1,5 @@
+{
+  "paused": true,
+  "bumpsAtPause": 1,
+  "final": 3
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-callback/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-callback/test.js
@@ -1,0 +1,16 @@
+import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
+import { bumpCount } from "./counter.js";
+import { writeFileSync } from "fs";
+
+const PAUSE_AFTER_MS = 150; // fires inside the callback's 400ms sleep
+
+const pause = new AbortController();
+setTimeout(() => pause.abort(), PAUSE_AFTER_MS);
+const first = await main({ pauseSignal: pause.signal });
+const paused = isPaused(first.data);
+const bumpsAtPause = bumpCount();
+const resumed = paused ? await resumeFromCheckpoint(first.data) : first;
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ paused, bumpsAtPause, final: resumed.data }, null, 2),
+);

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-tool/agent.agency
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-tool/agent.agency
@@ -1,0 +1,13 @@
+import { bump, bumpCount } from "./counter.js"
+
+def slowTool(): string {
+  """Sleeps, then returns pong."""
+  sleep(400ms)
+  bump()
+  return "pong"
+}
+
+node main(): string {
+  const answer = llm("call slowTool", { tools: [slowTool] })
+  return answer
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-tool/counter.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-tool/counter.js
@@ -1,0 +1,8 @@
+let bumps = 0;
+export function bump() {
+  bumps = bumps + 1;
+  return bumps;
+}
+export function bumpCount() {
+  return bumps;
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-tool/fixture.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-tool/fixture.json
@@ -1,0 +1,5 @@
+{
+  "paused": true,
+  "final": "done",
+  "toolRuns": 1
+}

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-tool/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-tool/llmMocks.json
@@ -1,0 +1,4 @@
+[
+  { "toolCall": { "name": "slowTool", "args": {} } },
+  { "return": "done" }
+]

--- a/packages/agency-lang/tests/agency-js/pause-signal-in-tool/test.js
+++ b/packages/agency-lang/tests/agency-js/pause-signal-in-tool/test.js
@@ -1,0 +1,18 @@
+import { main, isPaused, resumeFromCheckpoint } from "./agent.js";
+import { bumpCount } from "./counter.js";
+import { writeFileSync } from "fs";
+
+const PAUSE_AFTER_MS = 150; // fires inside the tool's 400ms sleep
+
+// A pause requested during a tool call waits until the tool loop finishes,
+// then lands on the next statement of the node. The tool runs once and its
+// result reaches the model's second turn.
+const pause = new AbortController();
+setTimeout(() => pause.abort(), PAUSE_AFTER_MS);
+const first = await main({ pauseSignal: pause.signal });
+const paused = isPaused(first.data);
+const resumed = paused ? await resumeFromCheckpoint(first.data) : first;
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ paused, final: resumed.data, toolRuns: bumpCount() }, null, 2),
+);

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -264,7 +265,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -289,7 +294,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -301,6 +306,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -303,7 +308,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -315,6 +320,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -278,7 +279,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -322,7 +323,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -347,7 +352,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -359,6 +364,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -264,7 +265,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -289,7 +294,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -301,6 +306,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -479,7 +484,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -491,6 +496,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -286,7 +287,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -454,7 +455,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -301,7 +306,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +318,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -276,7 +277,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -482,7 +487,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -494,6 +499,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -287,7 +288,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -457,7 +458,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -291,7 +292,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -443,7 +444,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -468,7 +473,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -480,6 +485,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -448,7 +453,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -460,6 +465,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -271,7 +272,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -423,7 +424,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -288,7 +293,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -300,6 +305,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -263,7 +264,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -301,7 +302,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -492,7 +493,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -517,7 +522,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -529,6 +534,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -540,7 +545,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -552,6 +557,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -312,7 +313,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -515,7 +516,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -284,7 +285,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -309,7 +314,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -321,6 +326,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -345,7 +350,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -357,6 +362,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/codeLiteral.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -320,7 +321,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -279,7 +280,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -464,7 +465,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -489,7 +494,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -501,6 +506,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -476,7 +481,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -488,6 +493,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comprehension.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -451,7 +452,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -295,7 +296,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -271,7 +272,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -420,7 +421,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -590,7 +591,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -722,7 +723,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -747,7 +752,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -759,6 +764,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -267,7 +268,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -392,7 +393,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -417,7 +422,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -429,6 +434,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -97,10 +97,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -94,8 +96,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -275,7 +276,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -427,7 +428,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -577,7 +578,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -727,7 +728,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -857,7 +858,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -252,7 +253,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -277,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -289,6 +294,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/effectAlways.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -283,7 +284,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -308,7 +313,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -320,6 +325,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -281,7 +282,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -306,7 +311,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -318,6 +323,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -265,7 +266,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -290,7 +295,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -302,6 +307,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -491,7 +496,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -503,6 +508,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -304,7 +305,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -466,7 +467,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -669,7 +674,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -681,6 +686,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -296,7 +297,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -473,7 +474,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -644,7 +645,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -284,7 +285,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -309,7 +314,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -321,6 +326,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -527,7 +532,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -539,6 +544,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -337,7 +338,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -502,7 +503,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -607,7 +612,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -619,6 +624,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -400,7 +401,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -582,7 +583,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -284,7 +285,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -309,7 +314,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -321,6 +326,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -527,7 +532,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -539,6 +544,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -337,7 +338,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -502,7 +503,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -371,7 +376,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -383,6 +388,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -346,7 +347,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -298,7 +299,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -472,7 +473,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -645,7 +646,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -819,7 +820,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -986,7 +987,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -1128,7 +1129,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -1283,7 +1284,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -1308,7 +1313,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -1320,11 +1325,13 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -1336,6 +1343,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -592,7 +597,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -604,6 +609,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -262,7 +263,7 @@ __stack.locals.foo = 1;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -408,7 +409,7 @@ await callHook({
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -567,7 +568,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -271,7 +272,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -420,7 +421,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -589,7 +590,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -751,7 +752,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -776,7 +781,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -788,6 +793,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -494,7 +499,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -506,6 +511,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -292,7 +293,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -469,7 +470,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -257,7 +258,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -334,7 +335,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -360,7 +365,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["foo"])
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -372,11 +377,13 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __fooNodeParams = [];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -388,6 +395,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -531,7 +536,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("main", ["greet"])
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -545,11 +550,13 @@ export async function greet(name: string, { messages: __invocationMessages, call
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __greetNodeParams = ["name"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -561,6 +568,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -271,7 +272,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -409,7 +410,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -505,7 +506,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -282,7 +283,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -307,7 +312,7 @@ await callHook({
     };
   }
 })
-export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet(name: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -321,6 +326,8 @@ export async function greet(name: string, { messages: __invocationMessages, call
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -435,7 +436,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -460,7 +465,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -472,6 +477,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -111,10 +111,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -21,15 +21,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -108,8 +110,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -36,6 +36,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -301,7 +302,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -492,7 +493,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -517,7 +522,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -529,6 +534,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -521,7 +526,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -533,6 +538,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -303,7 +304,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -496,7 +497,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -298,7 +299,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -323,7 +328,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -335,6 +340,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -281,7 +282,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -306,7 +311,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -318,6 +323,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -318,7 +319,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -519,7 +520,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -725,7 +726,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -750,7 +755,7 @@ await callHook({
     };
   }
 })
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",
@@ -764,6 +769,8 @@ export async function sayHi(name: any, { messages: __invocationMessages, callbac
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -339,7 +344,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -351,6 +356,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -314,7 +315,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -627,7 +632,7 @@ await callHook({
   }
 })
 graph.conditionalEdge("sayHi", ["foo2"])
-export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo2(name: string, age: number, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo2",
@@ -642,11 +647,13 @@ export async function foo2(name: string, age: number, { messages: __invocationMe
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __foo2NodeParams = ["name", "age"];
-export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function sayHi(name: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "sayHi",
@@ -660,6 +667,8 @@ export async function sayHi(name: any, { messages: __invocationMessages, callbac
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -318,7 +319,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -498,7 +499,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -601,7 +602,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -259,7 +260,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -284,7 +289,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -296,6 +301,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -335,7 +340,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -347,6 +352,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -310,7 +311,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -672,7 +673,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -697,7 +702,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -709,6 +714,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -337,7 +342,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -351,6 +356,8 @@ export async function main(x: string, { messages: __invocationMessages, callback
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -312,7 +313,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -314,7 +315,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -339,7 +344,7 @@ await callHook({
     };
   }
 })
-export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(x: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -353,6 +358,8 @@ export async function main(x: string, { messages: __invocationMessages, callback
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -267,7 +268,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -273,7 +274,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -381,7 +382,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -458,7 +459,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -485,7 +490,7 @@ await callHook({
 })
 graph.conditionalEdge("greet", ["processGreeting"])
 graph.conditionalEdge("main", ["greet"])
-export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function greet({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "greet",
@@ -497,11 +502,13 @@ export async function greet({ messages: __invocationMessages, callbacks: __invoc
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __greetNodeParams = [];
-export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function processGreeting(msg: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "processGreeting",
@@ -515,11 +522,13 @@ export async function processGreeting(msg: any, { messages: __invocationMessages
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __processGreetingNodeParams = ["msg"];
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -531,6 +540,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -302,7 +303,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -283,7 +284,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -489,7 +490,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -514,7 +519,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -526,6 +531,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -303,7 +308,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -315,6 +320,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -278,7 +279,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -281,7 +282,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -306,7 +311,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -318,6 +323,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -295,7 +296,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -879,7 +884,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -891,6 +896,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -271,7 +272,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -426,7 +427,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -602,7 +603,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -854,7 +855,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -314,7 +319,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -326,6 +331,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -289,7 +290,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -267,7 +268,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -365,7 +366,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -390,7 +395,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -402,11 +407,13 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __mainNodeParams = [];
-export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmTree({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmTree",
@@ -418,6 +425,8 @@ export async function llmTree({ messages: __invocationMessages, callbacks: __inv
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -285,7 +286,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -297,7 +298,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -275,7 +280,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -287,6 +292,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -250,7 +251,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -299,7 +304,7 @@ await callHook({
     };
   }
 })
-export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(message: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -313,6 +318,8 @@ export async function main(message: string, { messages: __invocationMessages, ca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -274,7 +275,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -268,7 +269,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -293,7 +298,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -305,6 +310,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -288,7 +293,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -300,6 +305,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -263,7 +264,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -285,7 +286,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -443,7 +444,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -732,7 +733,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -757,7 +762,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -769,6 +774,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -97,10 +97,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -22,6 +22,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -285,7 +286,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -7,15 +7,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -94,8 +96,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -310,7 +315,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -322,6 +327,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -303,7 +308,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -315,6 +320,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -278,7 +279,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -289,7 +294,7 @@ await callHook({
     };
   }
 })
-export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function analyzeData(input: string, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "analyzeData",
@@ -303,6 +308,8 @@ export async function analyzeData(input: string, { messages: __invocationMessage
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -264,7 +265,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -267,7 +268,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -292,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -304,6 +309,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -252,7 +253,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -277,7 +282,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -289,6 +294,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -289,7 +290,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -431,7 +432,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -456,7 +461,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -468,6 +473,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -267,7 +268,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -292,7 +297,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -304,6 +309,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -346,7 +351,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -358,6 +363,8 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -321,7 +322,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -243,7 +244,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -268,7 +273,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -280,6 +285,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -291,7 +292,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -316,7 +321,7 @@ await callHook({
     };
   }
 })
-export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function foo({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "foo",
@@ -328,6 +333,8 @@ export async function foo({ messages: __invocationMessages, callbacks: __invocat
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -800,7 +805,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -812,6 +817,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -449,7 +450,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -775,7 +776,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -572,7 +577,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -584,6 +589,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/type-patterns.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -395,7 +396,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -547,7 +548,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -344,7 +349,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -356,6 +361,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -319,7 +320,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -259,7 +260,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -284,7 +289,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -296,6 +301,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -283,7 +284,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -308,7 +313,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -320,6 +325,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -337,7 +342,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -349,6 +354,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -312,7 +313,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -285,7 +286,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -310,7 +315,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -322,6 +327,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -283,7 +284,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -308,7 +313,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -320,6 +325,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -268,7 +269,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -293,7 +298,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -305,6 +310,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -539,7 +544,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -551,11 +556,13 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }
 export const __mainNodeParams = [];
-export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function llmPatch({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "llmPatch",
@@ -567,6 +574,8 @@ export async function llmPatch({ messages: __invocationMessages, callbacks: __in
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -277,7 +278,7 @@ return;
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -416,7 +417,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {
@@ -514,7 +515,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -312,7 +317,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -324,6 +329,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -287,7 +288,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -312,7 +317,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -324,6 +329,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -287,7 +288,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -291,7 +292,7 @@ if (isAborted(__funcResult)) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -300,7 +301,7 @@ if (__response) {
       return runner.haltResult;
     }
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
   throw __error;
 }
 // All aborts — cancellations (Esc / abort) AND guard trips — are now a single
@@ -437,7 +438,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -462,7 +467,7 @@ await callHook({
     };
   }
 })
-export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main({ messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -474,6 +479,8 @@ export async function main({ messages: __invocationMessages, callbacks: __invoca
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -21,6 +21,7 @@ import {
   runExportedFunctionForServe as _runExportedFunctionForServe,
   runNodeForServe as _runNodeForServe,
   RestoreSignal,
+  RunControlSignal,
   AgencyAbort,
   AbortedResult,
   isAborted,
@@ -281,7 +282,7 @@ await callHook({
       data: undefined
     };
   } catch (__error) {
-    if (__error instanceof RestoreSignal) {
+    if (__error instanceof RunControlSignal) {
       throw __error
     }
     if (__error instanceof AgencyAbort) {

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -96,10 +96,10 @@ function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
-type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
-type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
-export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
+type __ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: __ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type __ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: __ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -6,15 +6,17 @@ import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
 import os from "os";
-import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, PausedCheckpoint, LLMClient, InvocationOptions, ResumeOverrides } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, claimFrameForScope, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
   __codeLiteral,
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  isPaused,
   respondToInterrupts as _respondToInterrupts,
   respondToInterruptsForServe as _respondToInterruptsForServe,
+  resumeFromCheckpoint as _resumeFromCheckpoint,
   resumeCliFromCheckpoint as _resumeCliFromCheckpoint,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -93,8 +95,11 @@ function propagate() { return { type: "propagate" as const }; }
 function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
-export { interrupt, isInterrupt, hasInterrupts, isDebugger };
-export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export { interrupt, isInterrupt, hasInterrupts, isPaused, isDebugger };
+type ResumeOptions = { overrides?: Record<string, unknown>; metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: ResumeOptions) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal });
+type ResumeFromCheckpointOptions = { metadata?: Record<string, any>; abortSignal?: AbortSignal; pauseSignal?: AbortSignal; invocation?: InvocationOptions };
+export const resumeFromCheckpoint = (paused: PausedCheckpoint, opts?: ResumeFromCheckpointOptions) => _resumeFromCheckpoint({ ctx: __globalCtx, paused, metadata: opts?.metadata, abortSignal: opts?.abortSignal, pauseSignal: opts?.pauseSignal, invocation: opts?.invocation });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 const __resumeFromCheckpoint = (checkpoint: Checkpoint, overrides?: ResumeOverrides) => _resumeCliFromCheckpoint({ ctx: __globalCtx, checkpoint, overrides });
 
@@ -306,7 +311,7 @@ await callHook({
     };
   }
 })
-export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput }: ({ messages?: any; callbacks?: any; invocationInput?: unknown } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
+export async function main(input: any, { messages: __invocationMessages, callbacks: __invocationCallbacks, config: __invocationConfig, traceId: __invocationTraceId, invocationInput: __invocationInput, abortSignal: __invocationAbortSignal, pauseSignal: __invocationPauseSignal }: ({ messages?: any; callbacks?: any; invocationInput?: unknown; abortSignal?: AbortSignal; pauseSignal?: AbortSignal } & InvocationOptions) = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
     nodeName: "main",
@@ -320,6 +325,8 @@ export async function main(input: any, { messages: __invocationMessages, callbac
       traceId: __invocationTraceId
     },
     input: __invocationInput,
+    abortSignal: __invocationAbortSignal,
+    pauseSignal: __invocationPauseSignal,
     initializeGlobals: __initializeGlobals
   });
 }


### PR DESCRIPTION
## What a host gets

A TypeScript host can pause a running node and continue it later:

```ts
import { main, isPaused, resumeFromCheckpoint } from "./agent.js";

const pause = new AbortController();
const result = await main({ pauseSignal: pause.signal });
// elsewhere: pause.abort()

if (isPaused(result.data)) {
  const resumed = await resumeFromCheckpoint(result.data);
}
```

- Every node export takes `pauseSignal` and `abortSignal` in its options object.
- `respondToInterrupts` takes both signals in `opts`.
- `resumeFromCheckpoint(paused, { metadata, abortSignal, pauseSignal, invocation })` continues a paused run. It keeps the paused run id, checks code fingerprints, and installs the root policy from `invocation`. It takes no overrides.
- `isPaused(data)` recognises `{ type: "paused", checkpoint, runId }`.

## How it works

Firing the signal sets `pauseRequested` on the execution context. `Runner.step()` and `Runner.hook()` check the flag after the guard-trip raise, stamp a checkpoint at that step, and throw `PauseSignal`. `runNodeCore` and `runResumeLoop` catch it and return the paused value in `data`. Handlers are not consulted, and cancel wins if both signals fire.

`resumeFromCheckpoint` and `respondToInterrupts` now share one resume lifecycle, `runResumeInvocation`, extracted from `respondToInterruptsCore`. `resumeCliFromCheckpoint` is still a separate copy with a different ending; moving it onto `runResumeInvocation` is a follow-up.

## Where a pause waits

The flag stays set, and the next step that can take it does, when the runner is:

- inside a handler body or a callback body;
- on a branch stack or inside a tool call. This is a change from the plan, which had the pause land inside the tool. When a branch raises an interrupt, the join saves the branch's threads and globals and then stamps the checkpoint against the parent stack. A thrown pause skips that join, so a checkpoint taken inside a tool could not be resumed. A pause requested during an `llm()` tool loop now lands on the node statement after the `llm()` call.

## Other changes in this PR

- `RestoreSignal` and `PauseSignal` extend `RunControlSignal`. The generated function and node catch blocks, callback errors, and the thread-end hook now re-throw the base class. Every golden under `tests/typescriptGenerator`, `tests/typescriptBuilder`, and `tests/debugger` changed for that rung and for the new exports.
- `__tryCall` re-throws `RunControlSignal`. Before this, `restore()` inside a `try` block became a failed result.
- Cancelling mid-run throws `AgencyAbort` with a `userKill` cause. An abort signal that is already aborted when the call starts throws `AgencyCancelledError`. Both behaviors existed before this PR; the new tests accept either name.

## Out of scope

Exported functions called through `__invokeFunction` cannot be paused. That path never enters `graph.run`, so there is no current node id to take a checkpoint against.

## Docs

- New dev note `docs/dev/runtime/pause.md`, indexed in `CLAUDE.md` and the `agency-runtime-docs` skill.
- A "Pausing a run from outside" section in `docs/site/guide/interrupts-from-typescript.md`, which the plan asked for.

## Tests

- Unit: `runner.test.ts` (check placement, each case that waits, cancel in both orders), `externalSignals.test.ts`, `pause.test.ts`, `result.test.ts`, `generatedCatch.test.ts`, `node.pause.test.ts`, `resumeFromCheckpoint.test.ts`, `nodeWrapperParams.test.ts`.
- agency-js: `pause-signal-basic` (resume in the same process and in a fresh one from JSON), `pause-signal-after-interrupt`, `pause-signal-in-tool`, `pause-signal-in-blocks` (handler registered again on resume), `pause-signal-in-callback`, `pause-signal-edges`.

Run locally: `pnpm vitest run lib/runtime lib/backends` (2829 passed), the six agency-js tests above, `pnpm run typecheck`, `pnpm run lint:structure`. I did not run the full agency or agency-js suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SmvrQbER8fjQd5WZyryD4
